### PR TITLE
Release of EntraOps Version 0.2

### DIFF
--- a/.github/workflows/Push-EntraOpsPrivilegedEAM.yaml
+++ b/.github/workflows/Push-EntraOpsPrivilegedEAM.yaml
@@ -89,7 +89,6 @@ jobs:
             Import-Module ./EntraOps
             Connect-EntraOps -AuthenticationType FederatedCredentials -TenantName ${env:TenantName} -ConfigFile ${env:ConfigFile}
             $CaTargetingGroupParams = $EntraOpsConfig.AutomatedConditionalAccessTargetGroups
-            Save-EntraOpsPrivilegedEAMWatchLists @CaTargetingGroupParams
             New-EntraOpsPrivilegedConditionalAccessGroup @CaTargetingGroupParams
             Update-EntraOpsPrivilegedConditionalAccessGroup @CaTargetingGroupParams            
           azPSVersion: latest

--- a/.github/workflows/Push-EntraOpsPrivilegedEAM.yaml
+++ b/.github/workflows/Push-EntraOpsPrivilegedEAM.yaml
@@ -7,6 +7,9 @@ env:
   ConfigFile: ./EntraOpsConfig.json
   IngestToWatchLists: false
   IngestToLogAnalytics: false
+  ApplyAdministrativeUnitAssignments: false
+  ApplyRmauAssignmentsForUnprotectedObjects: false
+  ApplyConditionalAccessTargetGroups: false  
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -56,6 +59,41 @@ jobs:
             $SentinelWatchListsParams = $EntraOpsConfig.SentinelWatchLists
             Save-EntraOpsPrivilegedEAMWatchLists @SentinelWatchListsParams
           azPSVersion: "latest"
+      - name: Apply Assignment for Privileged Users and Groups to (Restricted) Administrative Units
+        if: env.ApplyAdministrativeUnitAssignments == 'true'
+        uses: azure/powershell@v2
+        with:
+          inlineScript: |
+            Import-Module ./EntraOps
+            Connect-EntraOps -AuthenticationType FederatedCredentials -TenantName ${env:TenantName} -ConfigFile ${env:ConfigFile}
+            $AutomatedAuParams = $EntraOpsConfig.AutomatedAdministrativeUnitManagement
+            New-EntraOpsPrivilegedAdministrativeUnit @AutomatedAuParams
+            Update-EntraOpsPrivilegedAdministrativeUnit @AutomatedAuParams
+          azPSVersion: latest
+      - name: Apply Assignment for unprotected assets to (Restricted) Administrative Unit
+        if: env.ApplyRmauAssignmentsForUnprotectedObjects == 'true'
+        uses: azure/powershell@v2
+        with:
+          inlineScript: |
+            Import-Module ./EntraOps
+            Connect-EntraOps -AuthenticationType FederatedCredentials -TenantName ${env:TenantName} -ConfigFile ${env:ConfigFile}
+            $AutomatedUnprotectedRmauParams = $EntraOpsConfig.AutomatedRmauAssignmentsForUnprotectedObjects
+            New-EntraOpsPrivilegedUnprotectedAdministrativeUnit @AutomatedUnprotectedRmauParams
+            Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit @AutomatedUnprotectedRmauParams
+          azPSVersion: latest
+      - name: Apply Group Assignment for Conditional Access Policies
+        if: env.ApplyConditionalAccessTargetGroups == 'true'
+        uses: azure/powershell@v2
+        with:
+          inlineScript: |
+            Import-Module ./EntraOps
+            Connect-EntraOps -AuthenticationType FederatedCredentials -TenantName ${env:TenantName} -ConfigFile ${env:ConfigFile}
+            $CaTargetingGroupParams = $EntraOpsConfig.AutomatedConditionalAccessTargetGroups
+            Save-EntraOpsPrivilegedEAMWatchLists @CaTargetingGroupParams
+            New-EntraOpsPrivilegedConditionalAccessGroup @CaTargetingGroupParams
+            Update-EntraOpsPrivilegedConditionalAccessGroup @CaTargetingGroupParams            
+          azPSVersion: latest
+
       - name: Disconnect EntraOps
         uses: azure/powershell@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,23 @@ All essential changes on EntraOps will be documented in this changelog.
 
 ## [0.2] - 2024-07-31
   
-_Introduction of capabilities to automate assignment of privileges to Conditional Access Groups and (Restricted Management) Administrative Units but also added WatchLists for Workload IDs_
+Introduction of capabilities to automate assignment of privileges to Conditional Access Groups and (Restricted Management) Administrative Units but also added WatchLists for Workload IDs.
 
 ### Added
 
-- [#8](https://github.com/Cloud-Architekt/EntraOps/issues/8)
-  Automated update of Microsoft Sentinel WatchList Templates
-- [#15](https://github.com/Cloud-Architekt/EntraOps/issues/15)
-  Automated coverage of privileged assets in CA groups and RMAUs
-- [#22](https://github.com/Cloud-Architekt/EntraOps/issues/22)
-  Advanced WatchLists for Workload Identities 
+- Automated update of Microsoft Sentinel WatchList Templates [#8](https://github.com/Cloud-Architekt/EntraOps/issues/8)
+- Automated coverage of privileged assets in CA groups and RMAUs [#15](https://github.com/Cloud-Architekt/EntraOps/issues/15) 
+- Advanced WatchLists for Workload Identities [#22](https://github.com/Cloud-Architekt/EntraOps/issues/22) 
 
 ### Changed
-- [#19](https://github.com/Cloud-Architekt/EntraOps/issues/19)
-  Separated cmdlet for get classification for Control Plane scope
+- Separated cmdlet for get classification for Control Plane scope [#19](https://github.com/Cloud-Architekt/EntraOps/issues/19) 
 
-- [#20](https://github.com/Cloud-Architekt/EntraOps/issues/20)
-  Added support for -AsSecureString in Az PowerShell (upcoming breaking change)
+- Added support for -AsSecureString in Az PowerShell (upcoming breaking change) [#20](https://github.com/Cloud-Architekt/EntraOps/issues/20) 
 
 -  Added support for granting required permissions for automated assignment to CA and Administrative Unit
 
 ### Fixed
-- [#18](https://github.com/Cloud-Architekt/EntraOps/issues/18)
-    Remove Azure from ValidateSet until it's available
+- Remove Azure from ValidateSet until it's available [#18](https://github.com/Cloud-Architekt/EntraOps/issues/18) 
 
 ## [0.1] - 2024-06-27
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+
+# Change Log
+All essential changes on EntraOps will be documented in this changelog.
+
+## [0.2] - 2024-07-31
+  
+_Introduction of capabilities to automate assignment of privileges to Conditional Access Groups and (Restricted Management) Administrative Units but also added WatchLists for Workload IDs_
+
+### Added
+
+- [#8](https://github.com/Cloud-Architekt/EntraOps/issues/8)
+  Automated update of Microsoft Sentinel WatchList Templates
+- [#15](https://github.com/Cloud-Architekt/EntraOps/issues/15)
+  Automated coverage of privileged assets in CA groups and RMAUs
+- [#22](https://github.com/Cloud-Architekt/EntraOps/issues/22)
+  Advanced WatchLists for Workload Identities 
+
+### Changed
+- [#19](https://github.com/Cloud-Architekt/EntraOps/issues/19)
+  Separated cmdlet for get classification for Control Plane scope
+
+- [#20](https://github.com/Cloud-Architekt/EntraOps/issues/20)
+  Added support for -AsSecureString in Az PowerShell (upcoming breaking change)
+
+-  Added support for granting required permissions for automated assignment to CA and Administrative Unit
+
+### Fixed
+- [#18](https://github.com/Cloud-Architekt/EntraOps/issues/18)
+    Remove Azure from ValidateSet until it's available
+
+## [0.1] - 2024-06-27
+  
+_Initial release of EntraOps Privileged EAM with features to automate setup for GitHub repository,
+classification and ingestion of privileges in Microsoft Entra ID, Identity Governance and Microsoft Graph App Roles._

--- a/Classification/Templates/Classification_IdentityGovernance.json
+++ b/Classification/Templates/Classification_IdentityGovernance.json
@@ -12,7 +12,25 @@
                 "RoleDefinitionActions": [
                     "microsoft.entitlementManagement/allEntities/allTasks",
                     "microsoft.entitlementManagement/AccessPackageCatalog/AccessPackage/allTasks",
-                    "microsoft.entitlementManagement/AccessPackageCatalog/AccessPackage/GrantRequests/allTasks"
+                    "microsoft.entitlementManagement/AccessPackageCatalog/AccessPackage/GrantRequests/allTasks",
+                    "microsoft.entitlementManagement/AccessPackageCatalog/Create"
+                ]
+            }
+        ]
+    },
+    {
+        "EAMTierLevelName": "ManagementPlane",
+        "EAMTierLevelTagValue": "1",
+        "TierLevelDefinition": [
+            {
+                "Category": "Microsoft.IdentityGovernance",
+                "Service": "Entitlement Management",
+                "RoleAssignmentScopeName": [
+                    "/AccessPackageCatalog/*"
+                ],
+                "RoleDefinitionActions": [
+                    "microsoft.entitlementManagement/AccessPackageCatalog/Create",
+                    "microsoft.entitlementManagement/AccessPackageCatalog/allEntities/Read"
                 ]
             }
         ]

--- a/EntraOps/EntraOps.psd1
+++ b/EntraOps/EntraOps.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'EntraOps.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.1.0'
+    ModuleVersion        = '0.2.0'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Core', 'Desktop'

--- a/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
+++ b/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
@@ -72,13 +72,13 @@ function New-EntraOpsConfigFile {
         [boolean]$ApplyAutomatedEntraOpsUpdate = $true,
 
         [Parameter(Mandatory = $false)]
-        [boolean]$ApplyConditionalAccessTargetGroups = $true,
+        [boolean]$ApplyConditionalAccessTargetGroups = $false,
 
         [Parameter(Mandatory = $false)]
-        [boolean]$ApplyAdministrativeUnitAssignments = $true,
+        [boolean]$ApplyAdministrativeUnitAssignments = $false,
 
         [Parameter(Mandatory = $false)]
-        [boolean]$ApplyRmauAssignmentsForUnprotectedObjects = $true,
+        [boolean]$ApplyRmauAssignmentsForUnprotectedObjects = $false,
 
         [Parameter(Mandatory = $false)]
         [ValidateSet("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]

--- a/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
+++ b/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
@@ -144,7 +144,7 @@ function New-EntraOpsConfigFile {
         }
         SentinelWatchLists               = [ordered]@{
             IngestToWatchLists        = $IngestToWatchLists
-            AddToWatchListTemplates   = "None"
+            WatchListTemplates        = "None"
             SentinelWorkspaceName     = "Enter Log Analytics Workspace Name and run New-EntraOpsWorkloadIdentity to assign permissions"
             SentinelSubscriptionId    = "Enter Subscription Id of Log Analytics Workspace and run New-EntraOpsWorkloadIdentity to assign permissions"
             SentinelResourceGroupName = "Enter Resource Group of Log Analytics Workspace and run New-EntraOpsWorkloadIdentity to assign permissions"

--- a/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
+++ b/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
@@ -144,6 +144,7 @@ function New-EntraOpsConfigFile {
         }
         SentinelWatchLists               = [ordered]@{
             IngestToWatchLists        = $IngestToWatchLists
+            AddToWatchListTemplates   = "None"
             SentinelWorkspaceName     = "Enter Log Analytics Workspace Name and run New-EntraOpsWorkloadIdentity to assign permissions"
             SentinelSubscriptionId    = "Enter Subscription Id of Log Analytics Workspace and run New-EntraOpsWorkloadIdentity to assign permissions"
             SentinelResourceGroupName = "Enter Resource Group of Log Analytics Workspace and run New-EntraOpsWorkloadIdentity to assign permissions"

--- a/EntraOps/Public/Configuration/New-EntraOpsWorkloadIdentity.ps1
+++ b/EntraOps/Public/Configuration/New-EntraOpsWorkloadIdentity.ps1
@@ -224,7 +224,7 @@ function New-EntraOpsWorkloadIdentity {
             # Check if AU has been created successfully, wait for delay and retry if not available yet
             Try {
                 Do { Start-Sleep -Seconds 1 }
-                Until ($AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits/$($NewAdminUnitId)" -DisableCache))
+                Until ($AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits/$($NewAdminUnitId)" -DisableCache).Id)
                 Write-Host "$($AdminUnitName) - $($AdminUnitId) has been created successfully" -f Green
             }
             Catch {

--- a/EntraOps/Public/Configuration/Update-EntraOpsRequiredWorkflowParameters.ps1
+++ b/EntraOps/Public/Configuration/Update-EntraOpsRequiredWorkflowParameters.ps1
@@ -77,6 +77,21 @@ function Update-EntraOpsRequiredWorkflowParameters {
         $PushWorkflowObject.env.IngestToWatchLists = $Config.SentinelWatchLists.IngestToWatchLists
     }
 
+    if ($Config.AutomatedAdministrativeUnitManagement.ApplyAdministrativeUnitAssignments) {
+        # Set ApplyAdministrativeUnitAssignments Parameter
+        $PushWorkflowObject.env.ApplyAdministrativeUnitAssignments = $Config.AutomatedAdministrativeUnitManagement.ApplyAdministrativeUnitAssignments
+    }
+
+    if ($Config.AutomatedRmauAssignmentsForUnprotectedObjects.ApplyRmauAssignmentsForUnprotectedObjects) {
+        # Set ApplyRmauAssignmentsForUnprotectedObjects Parameter
+        $PushWorkflowObject.env.ApplyRmauAssignmentsForUnprotectedObjects = $Config.AutomatedRmauAssignmentsForUnprotectedObjects.ApplyRmauAssignmentsForUnprotectedObjects
+    }
+    
+    if ($Config.AutomatedConditionalAccessTargetGroups.ApplyConditionalAccessTargetGroups) {
+        # Set ApplyConditionalAccessTargetGroups Parameter
+        $PushWorkflowObject.env.ApplyConditionalAccessTargetGroups = $Config.AutomatedConditionalAccessTargetGroups.ApplyConditionalAccessTargetGroups
+    }    
+
     # Remove workflow_run trigger if not configured in config file
     if ($config.WorkflowTrigger.PushAfterPullWorkflowTrigger -eq $false -and $PushWorkflowObject.on.'workflow_run'.workflows -eq 'Pull-EntraOpsPrivilegedEAM') {
         $PushWorkflowObject.on.Remove('workflow_run')
@@ -98,14 +113,16 @@ function Update-EntraOpsRequiredWorkflowParameters {
     if ($Config.AutomatedControlPlaneScopeUpdate.ApplyAutomatedControlPlaneScopeUpdate) {
         # Set ApplyAutomatedControlPlaneScopeUpdate Parameter
         $PullWorkflowObject.env.ApplyAutomatedControlPlaneScopeUpdate = $Config.AutomatedControlPlaneScopeUpdate.ApplyAutomatedControlPlaneScopeUpdate
-    } else {
+    }
+    else {
         $PullWorkflowObject.env.ApplyAutomatedControlPlaneScopeUpdate = $false
     }
 
     if ($Config.AutomatedClassificationUpdate.ApplyAutomatedClassificationUpdate) {
         # Set ApplyAutomatedClassificationUpdate Parameter
         $PullWorkflowObject.env.ApplyAutomatedClassificationUpdate = $Config.AutomatedClassificationUpdate.ApplyAutomatedClassificationUpdate
-    } else {
+    }
+    else {
         $PullWorkflowObject.env.ApplyAutomatedClassificationUpdate = $false
     }
 
@@ -139,7 +156,8 @@ function Update-EntraOpsRequiredWorkflowParameters {
     if ($Config.AutomatedEntraOpsUpdate.ApplyAutomatedEntraOpsUpdate) {
         # Set ApplyAutomatedEntraOpsUpdate Parameter
         $UpdateWorkflowObject.env.ApplyAutomatedEntraOpsUpdate = $Config.AutomatedEntraOpsUpdate.ApplyAutomatedEntraOpsUpdate
-    } else {
+    }
+    else {
         $UpdateWorkflowObject.env.ApplyAutomatedEntraOpsUpdate = $false
     }
 

--- a/EntraOps/Public/Core/Connect-EntraOps.ps1
+++ b/EntraOps/Public/Core/Connect-EntraOps.ps1
@@ -69,8 +69,7 @@ function Connect-EntraOps {
         #region Switch between Microsoft Graph SDK (Invoke-MgGraphRequest) and Azure PowerShell only in combination with Invoke-RestMethod
         if ($UseAzPwshOnly -eq $true) {
             New-Variable -Name UseAzPwshOnly -Value $True -Scope Global -Force
-        }
-        else {
+        } else {
             New-Variable -Name UseAzPwshOnly -Value $False -Scope Global -Force
 
             $RequiredCoreModules = @{
@@ -114,8 +113,7 @@ function Connect-EntraOps {
                     Write-Output "Logging in to Microsoft Graph..."
                     Connect-MgGraph -TenantId $TenantId -NoWelcome -ErrorAction Stop -Scopes $Scopes
                     Write-Output "Succesfully logged in to Microsoft Graph"
-                }
-                catch {
+                } catch {
                     Write-Error -Message $_.Exception
                     throw $_.Exception
                 }
@@ -131,8 +129,7 @@ function Connect-EntraOps {
                     Write-Output "Logging in to Microsoft Graph..."
                     Connect-MgGraph -TenantId $TenantId -NoWelcome -ErrorAction Stop -Scopes $Scopes -UseDeviceAuthentication
                     Write-Output "Succesfully logged in to Microsoft Graph"
-                }
-                catch {
+                } catch {
                     Write-Error -Message $_.Exception
                     throw $_.Exception
                 }
@@ -145,8 +142,7 @@ function Connect-EntraOps {
                     Write-Output "Logging in to Microsoft Graph..."
                     Connect-MgGraph -Identity -ErrorAction Stop -NoWelcome
                     Write-Output "Succesfully logged in to Microsoft Graph"
-                }
-                catch {
+                } catch {
                     Write-Error -Message $_.Exception
                     throw $_.Exception
                 }
@@ -159,8 +155,7 @@ function Connect-EntraOps {
                     Write-Output "Logging in to Microsoft Graph..."
                     Connect-MgGraph -Identity -ClientId $AccountId -NoWelcome -ErrorAction Stop
                     Write-Output "Succesfully logged in to Microsoft Graph"
-                }
-                catch {
+                } catch {
                     Write-Error -Message $_.Exception
                     throw $_.Exception
                 }
@@ -172,8 +167,7 @@ function Connect-EntraOps {
                 try {
                     $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph" -AsSecureString).Token
                     Connect-MgGraph -AccessToken $SecureAccessToken -ErrorAction Stop -NoWelcome
-                }
-                catch {
+                } catch {
                     throw $_.Exception
                 }
             }
@@ -183,22 +177,18 @@ function Connect-EntraOps {
 
                     if ($UseAzPwshOnly -eq $true) {
                         New-Variable -Name MsGraphAccessToken -Value $MsGraphAccessToken -Scope Script -Force
-                    }
-                    else {
+                    } else {
                         $SecureMsGraphAccessToken = $MsGraphAccessToken | ConvertTo-SecureString -AsPlainText -Force
                         Connect-MgGraph -AccessToken $SecureMsGraphAccessToken -NoWelcome
                     }
-                }
-                elseif ($Null -ne (Get-AzContext).Tenant.Id) {
+                } elseif ($Null -ne (Get-AzContext).Tenant.Id) {
                     try {
-                        $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph" -AsSecureString).Token 
+                        $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph" -AsSecureString).Token
                         Connect-MgGraph -AccessToken $SecureAccessToken -ErrorAction Stop -NoWelcome
-                    }
-                    catch {
+                    } catch {
                         throw $_.Exception
                     }
-                }
-                else {
+                } else {
                     Write-Error -Message 'User or workload is not already authenticated. This authentication method is the default for EntraOps. Check "Get-Help Connect-EntraOps" to review the various options. Authenticated Azure PowerShell session is required for using "AlreadyAuthenticated" mode.'
                 }
             }
@@ -210,8 +200,7 @@ function Connect-EntraOps {
             Write-Verbose -Message "Connected to Azure Management"
             $AzContext = Get-AzContext | Select-Object Account, Tenant, TokenCache
             Write-Verbose $($AzContext)
-        }
-        else {
+        } else {
             Write-Verbose -Message "Connected to Azure Management"
             $AzContext = Get-AzContext | Select-Object Account, Tenant, TokenCache
             Write-Verbose $($AzContext)
@@ -230,18 +219,17 @@ function Connect-EntraOps {
         if ($ConfigFilePath) {
             try {
                 $EntraOpsConfig = Get-Content -Path $ConfigFilePath | ConvertFrom-Json -Depth 10 -AsHashtable
-            }
-            catch {
+            } catch {
                 Write-Error "Issue to import config file $($ConfigFilePath)! Check if the file exists and is in JSON format."
             }
             # Remove Ingest or Apply* parameters from config file and show configuration
             $EntraOpsConfig.AutomatedClassificationUpdate.Remove("ApplyAutomatedClassificationUpdate")
             $EntraOpsConfig.AutomatedControlPlaneScopeUpdate.Remove("ApplyAutomatedControlPlaneScopeUpdate")
-            $EntraOpsConfig.LogAnalytics.Remove("IngestToLogAnalytics")
-            $EntraOpsConfig.SentinelWatchLists.Remove("IngestToWatchLists")
-            $EntraOpsConfig.AutomatedAdministrativeUnitManagement.Remove("ApplyAdministrativeUnitAssignments")
-            $EntraOpsConfig.AutomatedConditionalAccessTargetGroups.Remove("ApplyConditionalAccessTargetGroups")
-            $EntraOpsConfig.AutomatedRmauAssignmentsForUnprotectedObjects.Remove("ApplyRmauAssignmentsForUnprotectedObjects")
+            if ($EntraOpsConfig.LogAnalytics) { $EntraOpsConfig.LogAnalytics.Remove("IngestToLogAnalytics") }
+            if ($EntraOpsConfig.SentinelWatchLists) { $EntraOpsConfig.SentinelWatchLists.Remove("IngestToWatchLists") }
+            if ($EntraOpsConfig.AutomatedAdministrativeUnitManagement) { $EntraOpsConfig.AutomatedAdministrativeUnitManagement.Remove("ApplyAdministrativeUnitAssignments") }
+            if ($EntraOpsConfig.AutomatedConditionalAccessTargetGroups) { $EntraOpsConfig.AutomatedConditionalAccessTargetGroups.Remove("ApplyConditionalAccessTargetGroups") }
+            if ($EntraOpsConfig.AutomatedRmauAssignmentsForUnprotectedObjects) { $EntraOpsConfig.AutomatedRmauAssignmentsForUnprotectedObjects.Remove("ApplyRmauAssignmentsForUnprotectedObjects") }
 
             New-Variable -Name EntraOpsConfig -Value $EntraOpsConfig -Scope Global -Force
             Write-Verbose -Message "Config file $($ConfigFilePath) imported"
@@ -255,8 +243,7 @@ function Connect-EntraOps {
             New-Variable -Name DefaultFolderClassification -Value "$EntraOpsBaseFolder/Classification/$($TenantName)/" -Scope Global -Force
             New-Variable -Name DefaultFolderClassifiedEam -Value "$EntraOpsBaseFolder/PrivilegedEAM/$($TenantName)/" -Scope Global -Force
             Write-Verbose -Message "Multi Tenant in Repository"
-        }
-        else {
+        } else {
             New-Variable -Name DefaultFolderClassification -Value "$EntraOpsBaseFolder/Classification/" -Scope Global -Force
             New-Variable -Name DefaultFolderClassifiedEam -Value "$EntraOpsBaseFolder/PrivilegedEAM/" -Scope Global -Force
             Write-Verbose -Message "Single Tenant in Repository"

--- a/EntraOps/Public/Core/Connect-EntraOps.ps1
+++ b/EntraOps/Public/Core/Connect-EntraOps.ps1
@@ -234,11 +234,14 @@ function Connect-EntraOps {
             catch {
                 Write-Error "Issue to import config file $($ConfigFilePath)! Check if the file exists and is in JSON format."
             }
-            # Remove Ingest parameters from config file and show configuration
+            # Remove Ingest or Apply* parameters from config file and show configuration
             $EntraOpsConfig.AutomatedClassificationUpdate.Remove("ApplyAutomatedClassificationUpdate")
             $EntraOpsConfig.AutomatedControlPlaneScopeUpdate.Remove("ApplyAutomatedControlPlaneScopeUpdate")
             $EntraOpsConfig.LogAnalytics.Remove("IngestToLogAnalytics")
             $EntraOpsConfig.SentinelWatchLists.Remove("IngestToWatchLists")
+            $EntraOpsConfig.AutomatedAdministrativeUnitManagement.Remove("ApplyAdministrativeUnitAssignments")
+            $EntraOpsConfig.AutomatedConditionalAccessTargetGroups.Remove("ApplyConditionalAccessTargetGroups")
+            $EntraOpsConfig.AutomatedRmauAssignmentsForUnprotectedObjects.Remove("ApplyRmauAssignmentsForUnprotectedObjects")
 
             New-Variable -Name EntraOpsConfig -Value $EntraOpsConfig -Scope Global -Force
             Write-Verbose -Message "Config file $($ConfigFilePath) imported"

--- a/EntraOps/Public/Core/Connect-EntraOps.ps1
+++ b/EntraOps/Public/Core/Connect-EntraOps.ps1
@@ -170,7 +170,7 @@ function Connect-EntraOps {
                     throw "Federated environment is not already authenticated"
                 }
                 try {
-                    $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph").Token | ConvertTo-SecureString -AsPlainText -Force
+                    $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph" -AsSecureString).Token
                     Connect-MgGraph -AccessToken $SecureAccessToken -ErrorAction Stop -NoWelcome
                 }
                 catch {
@@ -191,7 +191,7 @@ function Connect-EntraOps {
                 }
                 elseif ($Null -ne (Get-AzContext).Tenant.Id) {
                     try {
-                        $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph").Token | ConvertTo-SecureString -AsPlainText -Force
+                        $SecureAccessToken = (Get-AzAccessToken -ResourceTypeName "MSGraph" -AsSecureString).Token 
                         Connect-MgGraph -AccessToken $SecureAccessToken -ErrorAction Stop -NoWelcome
                     }
                     catch {

--- a/EntraOps/Public/Core/Push-EntraOpsLogsIngestionAPI.ps1
+++ b/EntraOps/Public/Core/Push-EntraOpsLogsIngestionAPI.ps1
@@ -73,8 +73,8 @@ function Push-EntraOpsLogsIngestionAPI {
     Write-Verbose " ThrottleLimitMonitor: '$($ThrottleLimitMonitor)'"
 
     # Authentication
-    $AccessToken = (Get-AzAccessToken -ResourceUrl "https://monitor.azure.com/").Token
-    $headers = @{"Authorization" = "Bearer $AccessToken"; "Content-Type" = "application/json" }
+    $AccessToken = (Get-AzAccessToken -ResourceUrl "https://monitor.azure.com/" -AsSecureString).Token
+    $headers = @{"Authorization" = "Bearer $($AccessToken | ConvertFrom-SecureString -AsPlainText)"; "Content-Type" = "application/json" }
 
     # Add Timestamp to JSON data
     try {

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsClassificationControlPlaneObjects.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsClassificationControlPlaneObjects.ps1
@@ -184,7 +184,7 @@ function Get-EntraOpsClassificationControlPlaneObjects {
                 if ($null -ne (Invoke-EntraOpsMsGraphQuery -Method GET -Uri "/beta/directoryObjects/$($HighPrivilegedObjectId.PrincipalId)" )) {
                     $HighPrivilegedRoles = $HighPrivilegedObjectIdsFromAzGraph | Where-Object { $_.PrincipalId -eq $HighPrivilegedObjectId.PrincipalId -and $_.PrincipalType -eq $HighPrivilegedObjectId.PrincipalType } | Select-Object -Unique RoleScope, RoleName
                     $PrivilegedObject = Get-EntraOpsPrivilegedEntraObject -AadObjectId $HighPrivilegedObjectId.PrincipalId | Where-Object { $_.ObjectType -ne "unknown" }`
-                    | Select-Object ObjectId, tolower(ObjectType), ObjectSubType, ObjectDisplayName, ObjectSignInName, AssignedAdministrativeUnits, RestrictedManagementByRAG, RestrictedManagementByAadRole, RestrictedManagementByRMAU, OwnedDevices
+                    | Select-Object ObjectId, @{Name = 'ObjectType'; Expression = { $_.'ObjectType'.tolower() } }, ObjectSubType, ObjectDisplayName, ObjectSignInName, AssignedAdministrativeUnits, RestrictedManagementByRAG, RestrictedManagementByAadRole, RestrictedManagementByRMAU, OwnedDevices
                     $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationReason -Value $HighPrivilegedRoles -Force | Out-Null
                     $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationSource -Value "Azure Resource Graph" -Force | Out-Null
                     return $PrivilegedObject

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsClassificationControlPlaneObjects.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsClassificationControlPlaneObjects.ps1
@@ -1,0 +1,265 @@
+<#
+.SYNOPSIS
+    Get list of Control Plane objects by classification of various sources (e.g., EntraOps, Microsoft Security Exposure Management and Azure Resource Graph).
+
+.DESCRIPTION
+    Classification of Control Plane needs to consider the scope of sensitive permissions. For example, managing group membership of security groups should be managed as Control Plane by default.
+    This function creates a list of high-privileged objects by classification of various sources (e.g., EntraOps, Microsoft Security Exposure Management and Azure Resource Graph).
+
+.PARAMETER PrivilegedObjectClassificationSource
+    Source of privileged objects to identify the scope of privileged objects and update the classification definition file for Microsoft Entra ID.
+    Possible values are "All", "EntraOps", "PrivilegedObjectIds", "PrivilegedRolesFromAzGraph" and "PrivilegedEdgesFromExposureManagement".
+
+.PARAMETER EntraIdClassificationParameterFile
+    Path to the classification parameter file for Microsoft Entra ID. Default is ./Classification/Templates/Classification_AadResources.Param.json.
+
+.PARAMETER EntraIdCustomizedClassificationFile
+    Path to the customized classification file for Microsoft Entra ID. Default is ./Classification/<TenantName>/Classification_AadResources.json.
+    The file path will be recognized by the tenant name in the context of EntraOps and used for the classification.
+
+.PARAMETER EntraOpsEamFolder
+    Path to the folder where the EntraOps classification definition files are stored. Default is ./Classification.
+
+.PARAMETER EntraOpsScopes
+    Array of EntraOps scopes which should be considered for the analysis. Default selection are all available scopes: Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement and ResourceApps.
+
+.PARAMETER AzureHighPrivilegedRoles
+    Array of high privileged roles in Azure RBAC which should be considered for the analysis. Default selection are high-privileged roles: Owner, Role Based Access Control Administrator and User Access Administrator.
+
+.PARAMETER AzureHighPrivilegedScopes
+    Scope of high privileged roles in Azure RBAC which should be considered for the analysis. Default selection is all scopes including management groups.
+
+.PARAMETER ExposureCriticalityLevel
+    Criticality level of assets in Exposure Management which should be considered for the analysis. Default selection is criticality level <1.
+
+.PARAMETER PrivilegedObjectIds
+    Manual list of privileged object IDs to identify the scope of privileged objects and update the classification definition file for Microsoft Entra ID.
+
+.EXAMPLE
+    Get privileged objects from various Microsoft Entra RBACs and Microsoft Azure roles to identify the scope of privileged objects and update the classification definition file for Microsoft Entra ID.
+    Update-EntraOpsClassificationControlPlaneScope -PrivilegedObjectClassificationSource "EntraOps" -RBACSystems ("Azure","EntraID","IdentityGovernance","DeviceManagement","ResourceApps")
+
+.EXAMPLE
+    Get exposure graph edges from Microsoft Security Exposure Management with relation of "has permissions to", "can authenticate as", "has role on", "has credentials of" or "affecting" to assets with criticality level <1.
+    This identitfies objects with direct/indirect permissions which leads in attack/access paths to high sensitive assets which can be identified as Control Plane.
+    Update-EntraOpsClassificationControlPlaneScope -PrivilegedObjectClassificationSource "PrivilegedEdgesFromExposureManagement" -ExposureCriticalityLevel = "<1"
+
+.EXAMPLE
+    Get permanent role assignments in Azure RBAC from Azure Resource Graph for high privileged roles (Owner, Role Based Access Control Administrator or User Access Administrator) on specific high-privileged scope ("/", "/providers/microsoft.management/managementgroups/8693dc7e-63c1-47ab-a7ee-acfe488bf52a").
+    Update-EntraOpsClassificationControlPlaneScope -PrivilegedObjectClassificationSource "PrivilegedRolesFromAzGraph" -AzureHighPrivilegedRoles ("Owner", "Role Based Access Control Administrator", "User Access Administrator") -AzureHighPrivilegedScopes ("/", "/providers/microsoft.management/managementgroups/8693dc7e-63c1-47ab-a7ee-acfe488bf52a")
+
+.EXAMPLE
+    Use previous named data sources to identify high-privileged or sensitive objects from EntraOps, Azure RBAC and Exposure Management to update EntraOps classification definition file.
+    Update-EntraOpsClassificationControlPlaneScope -PrivilegedObjectClassificationSource "All"
+
+.EXAMPLE
+    Get list of privileged object IDs to identify the scope of privileged objects and update the classification definition file for Microsoft Entra ID.
+    $PrivilegedUser = Get-AzAdUser -filter "startswith(DisplayName,'adm')"
+    $PrivilegedGroups = Get-AzAdGroup -filter "startswith(DisplayName,'prg')"
+    $PrivilegedObjects = $PrivilegedUser + $PrivilegedGroups
+    Update-EntraOpsClassificationControlPlaneScope -PrivilegedObjectClassificationSource "PrivilegedObjectIds" -PrivilegedObjectIds $PrivilegedObjects
+
+#>
+
+function Get-EntraOpsClassificationControlPlaneObjects {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("All", "EntraOps", "PrivilegedObjectIds", "PrivilegedRolesFromAzGraph", "PrivilegedEdgesFromExposureManagement")]
+        [object]$PrivilegedObjectClassificationSource = "All"
+        ,
+        [Parameter(Mandatory = $false)]
+        [System.String]$EntraIdClassificationParameterFile = "$DefaultFolderClassification\Templates\Classification_AadResources.Param.json"
+        ,
+        [Parameter(Mandatory = $false)]
+        [System.String]$EntraIdCustomizedClassificationFile = "$DefaultFolderClassification\$($TenantNameContext)\Classification_AadResources.json"
+        ,
+        [Parameter(Mandatory = $false)]
+        [ValidateScript({ Test-Path $_ })]
+        [string]$EntraOpsEamFolder = "$DefaultFolderClassifiedEam"
+        ,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
+        [object]$EntraOpsScopes = ("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")
+        ,
+        [Parameter(Mandatory = $false)]
+        [object]$AzureHighPrivilegedRoles = ("Owner", "Role Based Access Control Administrator", "User Access Administrator")
+        ,
+        [Parameter(Mandatory = $false)]
+        [string]$AzureHighPrivilegedScopes = "*"
+        ,
+        [Parameter(Mandatory = $false)]
+        [string]$ExposureCriticalityLevel = "<1"
+        ,
+        [Parameter(Mandatory = $false)]
+        [object]$PrivilegedObjectIds
+    )
+
+    $PrivilegedObjects = @()
+
+    # Check if classification file custom and/or template file exists, choose custom template for tenant if available
+    if (!(Test-Path -Path "$($DefaultFolderClassification)/$($TenantNameContext))")) {
+        try {
+            New-Item -Path "$($DefaultFolderClassification)/$($TenantNameContext)" -ItemType Directory -Force | Out-Null
+        }
+        catch {
+            Write-Error "Failed to create folder $($EntraIdCustomizedClassificationFile)! $_.Exception.Message"
+        }
+    }
+
+    #region Get list of all privileged objects in Entra with classification on Control Plane by Custom Security Attribute or EntraOps Classification
+    if ($PrivilegedObjectClassificationSource -eq "All" -or $PrivilegedObjectClassificationSource -contains "EntraOps") {
+        Write-Host "Get privileged objects from EntraOps..."
+        $EntraOpsAllPrivilegedObjects = foreach ($EntraOpsScope in $EntraOpsScopes) {
+            try {
+                Get-Content -Path $EntraOpsEamFolder\$($EntraOpsScope)\$($EntraOpsScope).json -ErrorAction Stop | ConvertFrom-Json -Depth 10
+            }
+            catch {
+                Write-Warning "No privileged objects found for $($EntraOpsScope) in EntraOps! $_.Exception.Message"
+            }
+        }
+
+        if ($null -eq $EntraOpsAllPrivilegedObjects) {
+            Write-Warning "No privileged objects found in EntraOps!"
+        }
+        else {
+            $EntraOpsObjectClassification = $EntraOpsAllPrivilegedObjects | Where-Object { $_.ObjectAdminTierLevelName -eq "ControlPlane" } `
+            | ForEach-Object {
+                $PrivilegedObject = $_ | Select-Object ObjectId, ObjectType, ObjectSubType, ObjectDisplayName, ObjectUserPrincipalName, AssignedAdministrativeUnits, RestrictedManagementByRAG, RestrictedManagementByAadRole, RestrictedManagementByRMAU, OwnedDevices
+                $ClassificationReason = @()
+                $ClassificationReason += @("ObjectAdminTierLevelName")
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ObjectSignInName -Value ($PrivilegedObject.ObjectUserPrincipalName) -Force | Out-Null
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationReason -Value $ClassificationReason -Force | Out-Null
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationSource -Value "EntraOps" -Force | Out-Null                
+                return $PrivilegedObject
+            }
+
+            $EntraOpsRoleClassification = $EntraOpsAllPrivilegedObjects | Where-Object { $_.Classification.AdminTierLevelName -contains "ControlPlane" } `
+            | ForEach-Object {
+                $PrivilegedObject = $_ | Select-Object ObjectId, ObjectType, ObjectSubType, ObjectDisplayName, ObjectUserPrincipalName, AssignedAdministrativeUnits, RestrictedManagementByRAG, RestrictedManagementByAadRole, RestrictedManagementByRMAU, OwnedDevices, RoleSystem
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ObjectSignInName -Value ($PrivilegedObject.ObjectUserPrincipalName) -Force | Out-Null
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationReason -Value ($PrivilegedObject | Select-Object -Unique RoleSystem) -Force | Out-Null
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationSource -Value "EntraOps" -Force | Out-Null
+                return $PrivilegedObject
+            }
+
+            $PrivilegedObjects += $EntraOpsObjectClassification + $EntraOpsRoleClassification
+        }
+    }
+    #endregion
+
+    #region Get list of all privileged objects by Azure Resource Graph
+    if ($PrivilegedObjectClassificationSource -eq "All" -or $PrivilegedObjectClassificationSource -contains "AzResourceGraph") {
+        Write-Host "Get privileged objects from Azure Resource Graph..."
+        # Query template and update them with parameter value of high privileged Azure roles and scopes
+        $Query = 'AuthorizationResources
+    | where type =~ "microsoft.authorization/roleassignments"
+    | extend principalType = tostring(properties["principalType"])
+    | extend principalId = tostring(properties["principalId"])
+    | extend roleDefinitionId = tolower(tostring(properties["roleDefinitionId"]))
+    | extend scope = tolower(tostring(properties["scope"]))
+    | where isnotempty(scope)
+    | join kind=inner ( AuthorizationResources
+    | where type =~ "microsoft.authorization/roledefinitions"
+    | extend roleDefinitionId = tolower(id)
+    | mv-expand parse_json(properties.assignableScopes)
+    | extend RoleScope = tolower(properties.assignableScopes)
+    | mv-expand parse_json(RoleScope)
+    | extend RoleName = (properties.roleName)
+    | where RoleName in (%AzureHighPrivilegedRoles%)
+    ) on roleDefinitionId
+    | project PrincipalId = principalId, PrincipalType = tolower(principalType), RoleScope, RoleName'
+        $Query = $Query.Replace("%AzureHighPrivilegedRoles%", "'$($AzureHighPrivilegedRoles -join "', '")'")
+        if ($null -ne $AzureHighPrivilegedScopes -and $AzureHighPrivilegedScopes -ne "*") {
+            $Scopes = "'$($AzureHighPrivilegedScopes -join "', '")'"
+            $Query = $Query.Replace("isnotempty(scope)", "scope in ($($Scopes))")
+        }
+
+        # Get details of high privileged objects
+        $HighPrivilegedObjectIdsFromAzGraph = (Invoke-EntraOpsAzGraphQuery -KqlQuery $Query)
+        $PrivilegedObjects += $HighPrivilegedObjectIdsFromAzGraph | Select-Object -Unique PrincipalId, PrincipalType | foreach-object {
+            $HighPrivilegedObjectId = $_
+            try {
+                if ($null -ne (Invoke-EntraOpsMsGraphQuery -Method GET -Uri "/beta/directoryObjects/$($HighPrivilegedObjectId.PrincipalId)" )) {
+                    $HighPrivilegedRoles = $HighPrivilegedObjectIdsFromAzGraph | Where-Object { $_.PrincipalId -eq $HighPrivilegedObjectId.PrincipalId -and $_.PrincipalType -eq $HighPrivilegedObjectId.PrincipalType } | Select-Object -Unique RoleScope, RoleName
+                    $PrivilegedObject = Get-EntraOpsPrivilegedEntraObject -AadObjectId $HighPrivilegedObjectId.PrincipalId | Where-Object { $_.ObjectType -ne "unknown" }`
+                    | Select-Object ObjectId, tolower(ObjectType), ObjectSubType, ObjectDisplayName, ObjectSignInName, AssignedAdministrativeUnits, RestrictedManagementByRAG, RestrictedManagementByAadRole, RestrictedManagementByRMAU, OwnedDevices
+                    $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationReason -Value $HighPrivilegedRoles -Force | Out-Null
+                    $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationSource -Value "Azure Resource Graph" -Force | Out-Null
+                    return $PrivilegedObject
+                }
+            }
+            catch {
+                Write-Warning "High privileged object with id $($HighPrivilegedObjectId.PrincipalId) not found! $_"
+            }
+        }
+    }
+    #endregion
+
+    #region Get list of all privileged objects by Microsoft Exposure Management
+    if ($PrivilegedObjectClassificationSource -eq "All" -or $PrivilegedObjectClassificationSource -contains "PrivilegedEdgesFromExposureManagement") {
+        Write-Host "Get privileged objects from exposure graph edges and nodes in Exposure Management..."
+        $Query = '
+        let Tier0CloudResources = ExposureGraphNodes
+        | where isnotnull(NodeProperties.rawData.criticalityLevel) and (NodeProperties.rawData.criticalityLevel.criticalityLevel %CriticalLevel%) and (NodeProperties.rawData.environmentName == "Azure");
+        let Tier0EntraObjects = ExposureGraphNodes
+            | where isnotnull(NodeProperties.rawData.criticalityLevel) and (NodeProperties.rawData.criticalityLevel.criticalityLevel %CriticalLevel%) and (NodeProperties.rawData.primaryProvider == "AzureActiveDirectory");
+        let Tier0Devices = ExposureGraphNodes
+            | where isnotnull(NodeProperties.rawData.criticalityLevel) and (NodeProperties.rawData.criticalityLevel.criticalityLevel %CriticalLevel%) and (NodeLabel == "device") and (NodeProperties.rawData.isAzureADJoined == true);
+        let Tier0Assets = union Tier0EntraObjects, Tier0Devices, Tier0CloudResources | project NodeId;
+        let SensitiveRelation = dynamic(["has permissions to","can authenticate as","has role on","has credentials of","affecting", "can authenticate as", "Member of", "frequently logged in by"]);
+        // Devices are not supported yet, no AadObject Id available in ExposureGraphNodes, DeviceInfo shows only AadDeviceId
+        let FilteredNodes = dynamic(["user","group","serviceprincipal","managedidentity","device"]);
+        ExposureGraphEdges
+        | where EdgeLabel in (SensitiveRelation) and (TargetNodeId in (Tier0Assets) or SourceNodeId in (Tier0Assets)) and SourceNodeLabel in (FilteredNodes)
+        | join kind=leftouter ( ExposureGraphNodes
+            | mv-expand parse_json(EntityIds)
+            | where parse_json(EntityIds).type == "AadObjectId"
+            | extend AadObjectId = tostring(parse_json(EntityIds).id)
+            | extend TenantId = extract("tenantid=([\\w-]+)", 1, AadObjectId)
+            | extend ObjectId = extract("objectid=([\\w-]+)", 1, AadObjectId)
+            | project ObjectDisplayName = NodeName, ObjectType = NodeLabel, ObjectId, NodeId) on $left.SourceNodeId == $right.NodeId
+        | where isnotempty(ObjectId)
+        | extend ClassificationReason = bag_pack_columns(EdgeLabel, TargetNodeName)
+        | summarize by ObjectDisplayName, SourceNodeName, tolower(ObjectType), ObjectId, NodeId, tostring(ClassificationReason)'
+        $Query = $Query.Replace("%CriticalLevel%", $ExposureCriticalityLevel)
+        $Body = @{
+            "Query" = $Query;
+        } | ConvertTo-Json
+        $PrivilegedObjectsGraphEdges = (Invoke-EntraOpsMsGraphQuery -Method POST -Uri "/beta/security/runHuntingQuery" -Body $Body).results
+        if ($null -ne $PrivilegedObjectsGraphEdges) {
+            $PrivilegedObjects += $PrivilegedObjectsGraphEdges | Select-Object -Unique ObjectDisplayName, ObjectId, ObjectType | ForEach-Object {
+                $GraphEdge = $_
+                $PrivilegedObject = Get-EntraOpsPrivilegedEntraObject -AadObjectId $GraphEdge.ObjectId | Where-Object { $_.ObjectType -ne "unknown" }`
+                | Select-Object ObjectId, ObjectType, ObjectSubType, ObjectDisplayName, ObjectSignInName, AssignedAdministrativeUnits, RestrictedManagementByRAG, RestrictedManagementByAadRole, RestrictedManagementByRMAU, OwnedDevices
+                $ClassificationReason = @()
+                $ClassificationReason += ($PrivilegedObjectsGraphEdges | Where-Object { $_.ObjectId -eq $GraphEdge.ObjectId -and $_.ObjectType -eq $GraphEdge.ObjectType }).ClassificationReason | ConvertFrom-Json
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationReason -Value $ClassificationReason -Force | Out-Null
+                $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationSource -Value "XSPM" -Force | Out-Null
+                return $PrivilegedObject
+            }
+        }
+    }
+    #endregion
+
+    #region Get list of all privileged objects by manual list of ObjectIds
+    if ($PrivilegedObjectClassificationSource -contains "PrivilegedObjectIds" -and $null -ne $PrivilegedObjectIds) {
+        Write-Host "Get privileged objects from manual list of object ids..."
+        $PrivilegedObjects = $PrivilegedObjectIds | ForEach-Object {
+            $PrivilegedObject = Get-EntraOpsPrivilegedEntraObject -AadObjectId $_
+            $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationReason -Value @("Manual") -Force | Out-Null
+            $PrivilegedObject | Add-Member -MemberType NoteProperty -Name ClassificationSource -Value "Manual" -Force | Out-Null
+        }
+    }
+    #endregion
+
+    #region Summarize and return list of privileged objects
+    $PrivilegedObjects | Select-Object -Unique ObjectId, ObjectType, ObjectSubType, ObjectDisplayName, ObjectSignInName, RestrictedManagementByAadRole, RestrictedManagementByRAG, RestrictedManagementByRMAU, OwnedDevices, AssignedAdministrativeUnits | ForEach-Object {
+        $PrivilegedObject = $_
+        $Classifications = $PrivilegedObjects | Where-Object { $_.ObjectId -eq $PrivilegedObject.ObjectId -and $_.ObjectType -eq $PrivilegedObject.ObjectType } | select-object ClassificationReason, ClassificationSource
+        $PrivilegedObject | Add-Member -MemberType NoteProperty -Name Classification -Value $Classifications -Force | Out-Null
+        return $PrivilegedObject
+    }
+    #endregion
+}

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAM.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAM.ps1
@@ -18,7 +18,7 @@ function Get-EntraOpsPrivilegedEAM {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $False)]
-        [ValidateSet("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
         [Array]$RbacSystems = ("EntraID", "IdentityGovernance", "ResourceApps")
         ,
         [Parameter(Mandatory = $False)]
@@ -29,21 +29,6 @@ function Get-EntraOpsPrivilegedEAM {
         Write-Host "Clearing cache before analyzing RBAC and classification data"
         Clear-EntraOpsCache
     }
-
-    #region Azure
-    if ($RbacSystems -contains "Azure") {
-        $EamAzure = Get-EntraOpsPrivilegedEamAzure
-        $EamAzure = $EamAzure | where-object { $null -ne $_.ObjectType -and $null -ne $_.ObjectId }
-        $EamAzure
-    }
-    #endregion
-
-    #region Azure Billing
-    if ($RbacSystems -contains "AzureBilling") {
-        $EamAzureBilling = Get-EntraOpsPrivilegedEamAzureBilling -GlobalExclusion $false
-        $EamAzureBilling = $EamAzureBilling | where-object { $null -ne $_.ObjectType -and $null -ne $_.ObjectId }
-    }
-    #endregion
 
     #region Entra ID
     if ($RbacSystems -contains "EntraID") {

--- a/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedAdministrativeUnit.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Creates (Restricted Management) Administrative Units based on EntraOps classification.
+
+.DESCRIPTION
+    (Restricted Management) Administrative Units for the different Enterprise Access Levels will be created based on the classification of EntraOps.
+
+.PARAMETER ApplyToAccessTierLevel
+    Array of Access Tier Levels to be processed. Default is ControlPlane, ManagementPlane.
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.PARAMETER RestrictedAUMode
+    Parameter to define the mode of creating Restricted Management Administrative Units. Default is Selected.
+    Selected will not create RMAU for Tier0 but also EntraID and Identity Governance RBACs. Mostly those are the RBACs which using role-assignable groups and are already restricted.
+
+.EXAMPLE
+    Create administrative units for EntraID, IdentityGovernance and ResourceApps RBAC systems with User and Group objectss
+    New-EntraOpsPrivilegedAdministrativeUnit -RbacSystems ("EntraID", "IdentityGovernance") -RestrictedAUMode "Selected"
+#>
+
+function New-EntraOpsPrivilegedAdministrativeUnit {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ControlPlane", "ManagementPlane")]
+        [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("None", "Selected", "All")]
+        [string]$RestrictedAuMode = "Selected" #Default value will not create RMAU for Tier0 and EntraID and Identity Governance RBACs
+    )
+
+    foreach ($RbacSystem in $RbacSystems) {
+
+        # Get EAM classification files
+        if ($RbacSystem -eq "EntraID") {
+            $ClassificationTemplateSubFolder = "AadResources"
+        }
+        else {
+            $ClassificationTemplateSubFolder = $RbacSystem
+        }
+
+        $ClassificationTemplates = "$DefaultFolderClassification/Templates/Classification_$($ClassificationTemplateSubFolder).json"
+
+        $PrivilegedEamClassificationFiles = @()
+        $PrivilegedEamClassificationFiles = Get-ChildItem -Path $ClassificationTemplates -Filter "*.json"
+        $PrivilegedEamClassifications = $PrivilegedEamClassificationFiles | foreach-object { Get-Content -Path $_.FullName | ConvertFrom-Json } | where-object { $_.EAMTierLevelName -in $ApplyToAccessTierLevel } | select-object -unique EAMTierLevelName, EAMTierLevelTagValue
+
+        foreach ($TierLevel in $PrivilegedEamClassifications) {
+
+            #region Verify existing or create new (Restricted Management) Administrative Units
+            $Name = "Tier" + $TierLevel.EAMTierLevelTagValue + "-" + $TierLevel.EAMTierLevelName + "." + $RbacSystem
+            $AdministrativeUnit = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$($Name)'" -OutputType PSObject -DisableCache).displayName
+            if (-not $AdministrativeUnit) {
+                Write-Host "Creating Administrative Unit $($Name)"
+
+                $AuParams = @{
+                    DisplayName = $Name
+                    Description = "This administrative unit contains assets of " + $TierLevel.EAMTierLevelName + " in " + $RbacSystem
+                }
+
+                # Create Administrative Unit (AU) or Restricted Management AU for related Tier level
+                if ($RestrictedAUMode -eq "All" -or ($RestrictedAUMode -eq "Selected" -and ($TierLevel.EAMTierLevelTagValue -ne "0") -and ($RbacSystem -ne "EntraID") -and ($RbacSystem -ne "IdentityGovernance"))) {
+                    $AuParams.IsMemberManagementRestricted = $true
+                    $body = $AuParams | ConvertTo-Json -Depth 10
+                    try {
+                        $CreatedAuObject = Invoke-EntraOpsMsGraphQuery -Method "POST" -Body $Body -Uri "/beta/administrativeUnits"
+                    }
+                    catch {
+                        Write-Warning "Can not create Administrative Unit $($AuParams.DisplayName)"
+                    }
+                }
+                else {
+                    $Body = $AuParams | ConvertTo-Json -Depth 10
+                    try {
+                        $CreatedAuObject = Invoke-EntraOpsMsGraphQuery -Method "POST" -Body $Body -Uri "/beta/administrativeUnits"
+                    }
+                    catch {
+                        Write-Warning "Can not create Administrative Unit $($AuParams.DisplayName)! Error: $_"
+                    }
+
+                }
+
+                # Check if AU has been created successfully, wait for delay and retry if not available yet
+                Try {
+                    Do { Start-Sleep -Seconds 1 }
+                    Until ($AdministrativeUnit = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits/$($CreatedAuObject.id)" -DisableCache))
+                    Write-Host "$($AdministrativeUnit.displayName) has been created successfully" -f Green
+                }
+                Catch {
+                    Write-Warning "$($AuParams.DisplayName) not available yet"
+                }
+            }
+            else {
+                Write-Host "Administrative Unit $($AdministrativeUnit) already exists"
+            }
+            #endregion
+        }
+
+    }
+}

--- a/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedAdministrativeUnit.ps1
@@ -29,6 +29,10 @@ function New-EntraOpsPrivilegedAdministrativeUnit {
         [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
         ,
         [Parameter(Mandatory = $False)]
+        [ValidateSet("User", "Group")]
+        [Array]$FilterObjectType = ("User", "Group")
+        ,        
+        [Parameter(Mandatory = $False)]
         [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
         [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
         ,

--- a/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedConditionalAccessGroup.ps1
+++ b/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedConditionalAccessGroup.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+    Create security groups based on EntraOps classification which can be used for targeting Conditional Access policies.
+
+.DESCRIPTION
+    Security Groups for the different Enterprise Access Levels will be created based on the classification of EntraOps.
+    This security groups can be used for targeting Conditional Access policies.
+
+.PARAMETER ApplyToAccessTierLevel
+    Array of Access Tier Levels to be processed. Default is ControlPlane, ManagementPlane.
+
+.PARAMETER FilterObjectType
+    Array of object types to be processed. Default is User, Group.
+
+.PARAMETER GroupPrefix
+    String to define the prefix of the Conditional Access Inclusion Groups. Default is "sug_Entra.CA.IncludeUsers.PrivilegedAccounts."
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.PARAMETER AdminUnitName
+    Name of the Administrative Unit which should be used by creating security groups. By default, groups will be created on directory-level and not assigned to an administrative unit.
+
+.EXAMPLE
+    Create Conditional Access Target Groups for EntraID, IdentityGovernance and ResourceApps RBAC systems on scope of the existing RMAU "Tier0-ControlPlane.0.ZTPolicy".
+    New-EntraOpsPrivilegedConditionalAccessGroup -GroupPrefix "sug_Entra.CA.IncludeUsers.PrivilegedAccounts." -RbacSystems ("EntraID", "IdentityGovernance") -AdminUnitName "Tier0-ControlPlane.0.ZTPolicy"
+#>
+
+function New-EntraOpsPrivilegedConditionalAccessGroup {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ControlPlane", "ManagementPlane")]
+        [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("User", "Group")]
+        [Array]$FilterObjectType = ("User", "Group")
+        ,
+        [Parameter(Mandatory = $False)]
+        [string]$GroupPrefix = "sug_Entra.CA.IncludeUsers.PrivilegedAccounts."
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+        ,
+        [Parameter(Mandatory = $False)]
+        [String]$AdminUnitName = $null
+    )
+
+    foreach ($RbacSystem in $RbacSystems) {
+
+        $Classification = "$DefaultFolderClassifiedEam/$RbacSystem/$($RbacSystem).json"
+
+        #region Get principals from EAM classification files and filter out objects without classification and objects not related to the RBAC system or object type filter
+        $PrivilegedEam = @()
+        $PrivilegedEam += Get-ChildItem -Path $Classification | foreach-object { Get-Content $_.FullName -Filter "*.json" | ConvertFrom-Json }
+        $PrivilegedEam = $PrivilegedEam | Where-Object { $_.ObjectType -in $FilterObjectType }
+        $PrivilegedEamCount = ($PrivilegedEam | Where-Object { $null -eq $_.Classification }).count
+        if ($PrivilegedEamCount -gt 0) { Write-Warning "Numbers of objects without classification: $PrivilegedEamCount" }
+        $PrivilegedEamClassifiedObjects = $PrivilegedEam | where-object { $_.Classification.AdminTierLevel -notcontains $null -and $_.RoleSystem -eq $RbacSystem }
+
+        # Get all unique AdminTierLevels which needs to be iterated for assigning objects to Conditional Access Target Groups
+        $PrivilegedEamClassificationTierLevels = $PrivilegedEamClassifiedObjects | ForEach-Object {
+            $Classification = $_.Classification
+            $Classification | where-object { $_.AdminTierLevelName -in $ApplyToAccessTierLevel } | select-object -unique AdminTierLevel, AdminTierLevelName
+        }
+        $PrivilegedEamClassificationTierLevels = $PrivilegedEamClassificationTierLevels | select-object -unique AdminTierLevel, AdminTierLevelName
+        #endregion
+
+        #region Create Conditional Access Target Groups
+        foreach ($TierLevel in $PrivilegedEamClassificationTierLevels) {
+
+            Write-Verbose "Create CA target group for $($RbacSystem) - $($TierLevel.AdminTierLevelName)"
+
+            $Name = "$GroupPrefix" + $TierLevel.AdminTierLevelName + "." + $($RbacSystem)
+            $Group = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/v1.0/groups?`$filter=DisplayName eq '$Name'" -OutputType PSObject -DisableCache)
+            if (-not $Group.id) {
+
+                $GroupParams = @{
+                    "@odata.type"   = "#Microsoft.Graph.Group"
+                    DisplayName     = $Name
+                    SecurityEnabled = $True
+                    MailEnabled     = $False
+                    MailNickname    = "NotSet"
+                    Description     = "This Conditional Access target groups contains assets of " + $TierLevel.AdminTierLevelName
+                }
+                $GroupParams = $GroupParams | ConvertTo-Json -Depth 10
+
+                Write-Host "Creating Conditional Access Target Group $($Name)"
+                if ($AdminUnitName) {
+                    try {
+                        $AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$($AdminUnitName)'" -DisableCache).id
+                        $CreatedGroupObject = Invoke-EntraOpsMsGraphQuery -Method "POST" -Body $GroupParams -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/"
+                    }
+                    catch {
+                        Write-Error "Can not create Group $($GroupParams.Name)! Error: $_"
+                    }
+                }
+                else {
+                    try {
+                        $CreatedGroupObject = Invoke-EntraOpsMsGraphQuery -Method "POST" -Body $GroupParams -Uri "/beta/groups"
+                    }
+                    catch {
+                        Write-Error "Can not create Group $($GroupParams.Name)! Error: $_"
+                    }
+                }
+
+                # Check if Security Group has been created successfully, wait for delay and retry if not available yet
+                Try {
+                    Do { Start-Sleep -Seconds 1 }
+                    Until ($Group = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/groups/$($CreatedGroupObject.id)" -DisableCache))
+                    Write-Host "$($Group.DisplayName) has been created successfully" -f Green
+                }
+                Catch {
+                    Write-Warning "$($GroupParams.DisplayName) not available yet"
+                }
+            }
+            else {
+                Write-Host "Security group $($Group.displayName) already exists"
+            }
+        }
+        #endregion
+    }
+}

--- a/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedConditionalAccessGroup.ps1
+++ b/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedConditionalAccessGroup.ps1
@@ -45,8 +45,8 @@ function New-EntraOpsPrivilegedConditionalAccessGroup {
         [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
         [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
         ,
-        [Parameter(Mandatory = $False)]
-        [String]$AdminUnitName = $null
+        [Parameter(Mandatory = $true)]
+        [String]$AdminUnitName
     )
 
     foreach ($RbacSystem in $RbacSystems) {
@@ -92,7 +92,7 @@ function New-EntraOpsPrivilegedConditionalAccessGroup {
                 if ($AdminUnitName) {
                     try {
                         $AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$($AdminUnitName)'" -DisableCache).id
-                        $CreatedGroupObject = Invoke-EntraOpsMsGraphQuery -Method "POST" -Body $GroupParams -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/"
+                        $CreatedGroupObject = Invoke-MgGraphRequest -Method "POST" -Body $GroupParams -Uri "https://graph.microsoft.com/beta/administrativeUnits/$($AdminUnitId)/members/" -ErrorAction Stop
                     }
                     catch {
                         Write-Error "Can not create Group $($GroupParams.Name)! Error: $_"

--- a/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
@@ -52,7 +52,7 @@ function New-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
 
     # Create Administrative Units for each Tier Level
     foreach ($TierLevel in $SelectedPrivilegedEamTierLevels) {
-        $Name = "Tier" + $TierLevel.AdminTierLevel + "-" + $TierLevel.AdminTierLevelName + ".UnprotectedAccounts"
+        $Name = "Tier" + $TierLevel.AdminTierLevel + "-" + $TierLevel.AdminTierLevelName + ".UnprotectedObjects"
         $AdministrativeUnit = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$Name'" -OutputType PSObject -DisableCache)
 
         if (-not $AdministrativeUnit.id) {

--- a/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/New-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+    Create Restricted Management AU for users and groups without any protection (by role-assignable groups, assigned directory role or existing RMAU membership) to avoid delegated management by lower privileged user.
+
+.DESCRIPTION
+    Create Restricted Management AU for users and groups without any protection (by role-assignable groups, assigned directory role or existing RMAU membership) to avoid delegated management by lower privileged user.
+
+.PARAMETER ApplyToAccessTierLevel
+    Array of Access Tier Levels to be processed. Default is ControlPlane, ManagementPlane.
+
+.PARAMETER FilterObjectType
+    Array of object types to be processed. Default is User, Group. Service Principal and application objects are not supported to be protected by RMAU.
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.EXAMPLE
+    Create RMAU for privileged users without any protection but privileges in RBAC Systems "IdentityGovernance".
+    New-EntraOpsPrivilegedUnprotectedAdministrativeUnit -RbacSystems ("EntraID", "IdentityGovernance")
+#>
+function New-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ControlPlane", "ManagementPlane")]
+        [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("User", "Group")]
+        [Array]$FilterObjectType = ("User", "Group")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+    )
+
+    # Get Tier Levels with unprotected privileged EAM objects
+    $PrivilegedEamTierLevels = foreach ($RbacSystem in $RbacSystems) {
+        # Get all privileged EAM objects
+        $PrivilegedEamObjects = Get-Content "$DefaultFolderClassifiedEam/$RbacSystem/$($RbacSystem).json" | ConvertFrom-Json
+
+        # Get all privileged EAM objects without any restricted management and their tier levels
+        $UnprotectedPrivilegedUser = $PrivilegedEamObjects | Where-Object { $_.RestrictedManagementByRAG -ne $True -and $_.RestrictedManagementByAadRole -ne $True -and $_.RestrictedManagementByRMAU -ne $True -and $_.ObjectType -in $FilterObjectType }
+        $UnprotectedPrivilegedUser.Classification | select-object -unique AdminTierLevelName, AdminTierLevel
+    }
+    $PrivilegedEamTierLevels = $PrivilegedEamTierLevels | Where-Object { $_.AdminTierLevelName -in $ApplyToAccessTierLevel } | select-object -unique AdminTierLevelName, AdminTierLevel
+
+    # Create Administrative Units for each Tier Level
+    foreach ($TierLevel in $PrivilegedEamTierLevels) {
+        $Name = "Tier" + $TierLevel.AdminTierLevel + "-" + $TierLevel.AdminTierLevelName + ".UnprotectedAccounts"
+        $AdministrativeUnit = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$Name'" -OutputType PSObject -DisableCache)
+
+        if (-not $AdministrativeUnit.id) {
+            Write-Host "Creating Administrative Unit $($Name)"
+
+            $AuParams = @{
+                DisplayName = $Name
+                Description = "This administrative unit contains assets of " + $($TierLevel.AdminTierLevelName) + " without any restricted management"
+            }
+
+            $AuParams.IsMemberManagementRestricted = $true
+            $Body = $AuParams | ConvertTo-Json -Depth 10
+
+            try {
+                $CreatedAuObject = Invoke-EntraOpsMsGraphQuery -Method "POST" -Body $Body -Uri "/beta/administrativeUnits"
+            }
+            catch {
+                Write-Warning "Can not create Administrative Unit $($AuParams.DisplayName)! Error: $_"
+            }
+
+            # Check if AU has been created successfully, wait for delay and retry if not available yet
+            Try {
+                Do { Start-Sleep -Seconds 1 }
+                Until ($AdministrativeUnit = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits/$($CreatedAuObject.id)" -DisableCache))
+                Write-Host "$($AdministrativeUnit.displayName) has been created successfully" -f Green
+            }
+            Catch {
+                Write-Warning "$($AuParams.DisplayName) not available yet"
+            }
+        }
+        else {
+            Write-Host "Administrativer Unit $($AdministrativeUnit.displayName) already exists"
+        }
+    }
+    #endregion
+}

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
@@ -1,0 +1,315 @@
+<#
+.SYNOPSIS
+    Get information of EntraOps Privileged EAM to add related entries to watchlist templates of HighValueAssets, IdentityCorrelation and VIP Users.
+
+.DESCRIPTION
+    Get information from EntraOps Privileged EAM to collect content and create the following watchlists:
+    - "High Value Assets" - The High Value Assets watchlist lists devices, resources, and other assets that have critical value in the organization, it includes the identified privileged devices from EntraOps and resources from Get-EntraOpsControlObjects.
+    - "VIP Users" - The VIP Users watchlist lists user accounts of employees that have high impact value in the organization, it includes the identified privileged users from EntraOps.
+    - "Identity Correlation" - The Identity Correlation watchlist lists related user accounts that belong to the same person, it includes the users which has been identified by using custom security attribute to connect privileged and regular work accounts.
+
+.PARAMETER TenantId
+    Tenant ID of the Microsoft Entra ID tenant. Default is the current tenant ID.
+
+.PARAMETER SentinelResourceGroupName
+    Resource group name of the Microsoft Sentinel workspace.
+
+.PARAMETER SentinelSubscriptionId
+    Subscription ID of the Microsoft Sentinel workspace.
+
+.PARAMETER SentinelWorkspaceName
+    Name of the Microsoft Sentinel workspace.
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.PARAMETER AddToWatchListTemplates
+    Define scope of WatchList templates which should be updated. Default is "All". Supported templates are "VIPUsers", "HighValueAssets", "IdentityCorrelation".
+
+.EXAMPLE
+    Save data of EntraOps Privileged EAM insights to WatchList in Microsoft Sentinel Workspace for correlation between work and privileged accounts.
+    Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists -AddtoWatchListTemplates "IdentityCorrelation" -SentinelSubscriptionId "3f72a077-c32a-423c-8503-41b93d3b0737" -SentinelResourceGroupName "EntraOpsResourceGroup" -SentinelWorkspaceName "EntraOpsWorkspace"
+#>
+function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [System.String]$TenantId = $TenantIdContext
+        ,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Object", "RoleClassification")]
+        [System.String]$UserClassificationSource = "RoleClassification"
+        ,
+        [Parameter(Mandatory = $false)]
+        [System.String]$ImportPath = $DefaultFolderClassifiedEam
+        ,
+        [Parameter(Mandatory = $True)]
+        [System.String]$SentinelResourceGroupName
+        ,
+        [Parameter(Mandatory = $True)]
+        [System.String]$SentinelSubscriptionId
+        ,
+        [Parameter(Mandatory = $True)]
+        [System.String]$SentinelWorkspaceName
+        ,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
+        [object]$RbacSystems = ("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("None", "All", "VIPUsers", "HighValueAssets", "IdentityCorrelation")]
+        [object]$AddToWatchListTemplates = "All"
+    )
+
+    Set-AzContext -SubscriptionId $SentinelSubscriptionId -TenantId $TenantNameContext | Out-Null
+
+    try {
+        Import-Module "SentinelEnrichment" -ErrorAction Stop
+    }
+    catch {
+        throw "Issue to import SentinelEnrichment modul!"
+    }
+
+    #region EntraOps Classification data
+    $Privileges = foreach ($Rbac in $RbacSystems) {
+        try {
+            Get-Content -Path "$($ImportPath)/$($Rbac)/$($Rbac).json" -ErrorAction Stop | ConvertFrom-Json -Depth 10
+        }
+        catch {
+            Write-Warning "No information found for $Rbac in file $($ImportPath)/$($Rbac)/$($Rbac).json"
+            continue
+        }
+    }
+    #endregion
+
+    #region VIP Users
+    if ($WatchListTemplates -eq "All" -or $WatchListTemplates -contains "VIPUsers") {
+        $WatchListName = "VIP Users"
+        $WatchListAlias = "VIPUsers"
+
+        function Get-VIPUsers {
+            $NewVipUserWatchlistItems = New-Object System.Collections.ArrayList
+
+            Write-Host "Collecting data for VIPUsers"
+            $PrivilegedUsers = $Privileges | Where-Object { $_.ObjectType -eq "user" } | Select-Object -unique ObjectId, ObjectUserPrincipalName, ObjectAdminTierLevelName
+            foreach ($PrivilegedUser in $PrivilegedUsers) {
+                $OnPremSid = Invoke-EntraOpsMsGraphQuery -Method Get -Uri "/v1.0/users/$($PrivilegedUser.ObjectId)?`$select=onPremisesSecurityIdentifier"
+
+                # Set tags
+                $Tags = New-Object System.Collections.ArrayList
+                $Tags.Add("EntraOps") | Out-Null
+                $Tags.Add("Automated Enrichment") | Out-Null
+
+                if ($UserClassificationSource -eq "Object") {
+                    # Get classification by custom security attribute of the privileged user
+                    $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -Unique ObjectAdminTierLevelName)[0]
+                    $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
+                }
+                else {
+                    # Get highest classification by assigned roles
+                    $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -ExpandProperty Classification | Sort-Object AdminTierLevel | Select-Object AdminTierLevelName)[0]
+                    $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
+                }
+
+                # Check if privileged user object has been classified and is different to role classification
+                if ($null -ne $PrivilegedUser.ObjectAdminTierLevelName -and $PrivilegedUser.ObjectAdminTierLevelName -ne $Classification.AdminTierLevelName) {
+                    $Tags.Add("TierBreach") | Out-Null
+                }
+
+                $CurrentItem = @{
+                    "User Identifier"     = $PrivilegedUser.ObjectId
+                    "User AAD Object Id"  = $PrivilegedUser.ObjectId
+                    "User On-Prem Sid"    = $OnPremSid.onPremisesSecurityIdentifier
+                    "User Principal Name" = $PrivilegedUser.ObjectUserPrincipalName
+                    "Tags"                = $Tags
+                }
+                $NewVipUserWatchlistItems.Add( $CurrentItem ) | Out-Null
+            }
+            return $NewVipUserWatchlistItems
+        }
+        $NewWatchlistItems = New-Object System.Collections.ArrayList
+        $NewWatchlistItems = Get-VIPUsers
+        Write-Verbose "Write information to watchlist: $WatchListName"
+
+        if ( $null -ne $NewWatchlistItems ) {
+            $SearchKey = "User Identifier"
+            $Parameters = @{
+                SearchKey         = $SearchKey
+                DisplayName       = $WatchListName
+                WatchListAlias    = $WatchListAlias
+                NewWatchlistItems = $NewWatchlistItems
+                SubscriptionId    = $SentinelSubscriptionId
+                ResourceGroupName = $SentinelResourceGroupName
+                WorkspaceName     = $SentinelWorkspaceName
+                Identifiers       = $Tags
+            }
+            Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
+        }
+    }
+    #endregion
+
+    #region Identity Correlation
+    if ($WatchListTemplates -eq "All" -or $WatchListTemplates -contains "IdentityCorrelation") {
+        $WatchListName = "Identity Correlation"
+        $WatchListAlias = "IdentityCorrelation"
+        function Get-IdentityCorrelation {
+            $NewIdentityCorrelationWatchlistItems = New-Object System.Collections.ArrayList
+
+            Write-Host "Collecting data for IdentityCorrelation"
+            $PrivilegedUsers = $Privileges | Where-Object { $_.ObjectType -eq "user" } | Select-Object -unique ObjectId, AssociatedWorkAccount, ObjectUserPrincipalName, ObjectAdminTierLevelName
+            $AssociatedWorkAccounts = $PrivilegedUsers | Select-Object -ExpandProperty AssociatedWorkAccount | Select-Object -Unique
+            foreach ($AssociatedWorkAccount in $AssociatedWorkAccounts) {
+                $WorkAccountDetails = Invoke-EntraOpsMsGraphQuery -Method Get -Uri "/v1.0/users/$($AssociatedWorkAccount)?`$select=id,userPrincipalName,onPremisesSecurityIdentifier,mail,employeeId"
+                $AssociatedPrivilegedUsers = $PrivilegedUsers | Where-Object { $_.AssociatedWorkAccount -eq $AssociatedWorkAccount } | Select-Object -unique ObjectId, ObjectUserPrincipalName, ObjectAdminTierLevelName
+                foreach ($AssociatedPrivilegedUser in $AssociatedPrivilegedUsers) {
+
+                    # Set tags
+                    $Tags = New-Object System.Collections.ArrayList
+                    $Tags.Add("EntraOps") | Out-Null
+                    $Tags.Add("Automated Enrichment") | Out-Null
+
+                    if ($UserClassificationSource -eq "Object") {
+                        # Get classification by custom security attribute of the privileged user
+                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -Unique ObjectAdminTierLevelName)[0]
+                        $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
+                    }
+                    else {
+                        # Get highest classification by assigned roles
+                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -ExpandProperty Classification | Sort-Object AdminTierLevel | Select-Object AdminTierLevelName)[0]
+                        $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
+                    }
+
+                    $CurrentItem = @{
+                        "User Identifier"                  = $WorkAccountDetails.id
+                        "User AAD Object Id"               = $WorkAccountDetails.id
+                        "User On-Prem Sid"                 = $WorkAccountDetails.onPremisesSecurityIdentifier
+                        "User Principal Name"              = $WorkAccountDetails.userPrincipalName
+                        "Employee Id"                      = $WorkAccountDetails.employeeId
+                        "Email"                            = $WorkAccountDetails.mail
+                        "Associated Privileged Account ID" = $AssociatedPrivilegedUser.ObjectId
+                        "Associated Privileged Account"    = $AssociatedPrivilegedUser.ObjectUserPrincipalName
+                        "Tags"                             = $Tags
+                    }
+                    $NewIdentityCorrelationWatchlistItems.Add( $CurrentItem ) | Out-Null
+                }
+            }
+            return $NewIdentityCorrelationWatchlistItems
+        }
+        $NewWatchlistItems = New-Object System.Collections.ArrayList
+        $NewWatchlistItems = Get-IdentityCorrelation
+        Write-Verbose "Write information to watchlist: $WatchListName"
+
+        if ( $null -ne $NewWatchlistItems ) {
+            $SearchKey = "Associated Privileged Account ID"
+            $Parameters = @{
+                SearchKey         = $SearchKey
+                DisplayName       = $WatchListName
+                WatchListAlias    = $WatchListAlias
+                NewWatchlistItems = $NewWatchlistItems
+                SubscriptionId    = $SentinelSubscriptionId
+                ResourceGroupName = $SentinelResourceGroupName
+                WorkspaceName     = $SentinelWorkspaceName
+                Identifiers       = $Tags
+            }
+            Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
+        }
+    }
+    #endregion
+
+    #region High Value Assets
+    if ($WatchListTemplates -eq "All" -or $WatchListTemplates -contains "HighValueAssets") {
+        $WatchListName = "High Value Assets"
+        $WatchListAlias = "HighValueAssets"
+        function Get-HighValueAssets {
+            Write-Host "Collecting data for High Value Assets"
+            $HighValueAssets = @()
+
+            $DeviceQuery = 'ExposureGraphNodes
+            | where isnotnull(NodeProperties.rawData.criticalityLevel) and (NodeProperties.rawData.criticalityLevel.criticalityLevel <1)
+            | where (NodeLabel == "device")
+            | extend "Asset Type" == "Device"
+            | mv-apply EntityIds = parse_json(EntityIds) on
+                (
+                where EntityIds.type =~ "DeviceInventoryId"
+                | extend
+                    DeviceId = tostring(EntityIds.DeviceInventoryId)
+                )
+            | extend DeviceId = tostring(parse_json(EntityIds).id)
+            | project ["AssetType"] = "Device",
+                    ["AssetId"] = DeviceId,
+                    ["AssetFQDN"] = NodeName,                    
+                    ["AssetName"] = NodeName,
+                    ["Tags"] = parse_json(NodeProperties).rawData.criticalityLevel.ruleNames;'
+            $Body = @{
+                "Query" = $DeviceQuery;
+            } | ConvertTo-Json
+            $Devices = (Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/runHuntingQuery" -Body $Body -OutputType PSObject).results
+            $HighValueAssets += $Devices
+
+            $AzureResourceQuery = 'ExposureGraphNodes
+            | where isnotnull(NodeProperties.rawData.criticalityLevel) and (NodeProperties.rawData.environmentName == "Azure")
+            | mv-apply EntityIds = parse_json(EntityIds) on
+                (
+                where EntityIds.type =~ "AzureResourceId"
+                | extend
+                    ResourceId = tostring(EntityIds.AzureResourceId)
+                )
+            | extend AzureResourceId = tostring(parse_json(EntityIds).id)
+            | extend IpAddresses = parse_json(NodeProperties).rawData.networkingComponentMetadata.ipAddresses
+            | project ["AssetType"] = "Azure resource",
+                    ["AssetId"] = AzureResourceId,
+                    ["AssetFQDN"] = NodeName,
+                    ["AssetName"] = NodeName,
+                    ["IPAddress"] = IpAddresses,
+                    ["Tags"] = parse_json(NodeProperties).rawData.criticalityLevel.ruleNames'
+            $Body = @{
+                "Query" = $AzureResourceQuery;
+            } | ConvertTo-Json
+            $AzureResources = (Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/security/runHuntingQuery" -Body $Body -OutputType PSObject).results
+            $HighValueAssets += $AzureResources
+
+            $NewHighValueAssetWatchlistItems = New-Object System.Collections.ArrayList
+
+            foreach ($HighValueAsset in $HighValueAssets) {
+                $Tags = New-Object System.Collections.ArrayList
+                $Tags.Add("EntraOps") | Out-Null
+                $Tags.Add("XSPM") | Out-Null
+                $Tags.Add("Automated Enrichment") | Out-Null
+                foreach ($Tag in $CriticalResource.Tags) {
+                    $Tags.Add( $Tag ) | Out-Null
+                }
+
+                $CurrentItem = @{
+                    "Asset Type" = $HighValueAsset.AssetType
+                    "Asset Id"   = $HighValueAsset.AssetId
+                    "Asset Name" = $HighValueAsset.AssetName
+                    "Asset FQDN" = $HighValueAsset.AssetFQDN
+                    "IP Address" = $HighValueAsset.IPAddress | ConvertTo-Json -Compress -AsArray
+                    "Tags"       = $Tags
+                }
+                $NewHighValueAssetWatchlistItems.Add( $CurrentItem ) | Out-Null
+            }
+            return $NewHighValueAssetWatchlistItems
+        }
+        $NewWatchlistItems = New-Object System.Collections.ArrayList
+        $NewWatchlistItems = Get-HighValueAssets
+        Write-Verbose "Write information to watchlist: $WatchListName"
+
+        if ( $null -ne $NewWatchlistItems ) {
+            $SearchKey = "Asset Id"
+            $Parameters = @{
+                SearchKey         = $SearchKey
+                DisplayName       = $WatchListName
+                WatchListAlias    = $WatchListAlias
+                NewWatchlistItems = $NewWatchlistItems
+                SubscriptionId    = $SentinelSubscriptionId
+                ResourceGroupName = $SentinelResourceGroupName
+                WorkspaceName     = $SentinelWorkspaceName
+                Identifiers       = $Tags
+            }
+            Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
+        }
+    }
+    #endregion
+}

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
@@ -23,12 +23,12 @@
 .PARAMETER RbacSystems
     Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
 
-.PARAMETER AddToWatchListTemplates
+.PARAMETER WatchListTemplates
     Define scope of WatchList templates which should be updated. Default is "All". Supported templates are "VIPUsers", "HighValueAssets", "IdentityCorrelation".
 
 .EXAMPLE
     Save data of EntraOps Privileged EAM insights to WatchList in Microsoft Sentinel Workspace for correlation between work and privileged accounts.
-    Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists -WatchListTemplates "IdentityCorrelation" -SentinelSubscriptionId "3f72a077-c32a-423c-8503-41b93d3b0737" -SentinelResourceGroupName "EntraOpsResourceGroup" -SentinelWorkspaceName "EntraOpsWorkspace"
+    Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists WatchListTemplates "IdentityCorrelation" -SentinelSubscriptionId "3f72a077-c32a-423c-8503-41b93d3b0737" -SentinelResourceGroupName "EntraOpsResourceGroup" -SentinelWorkspaceName "EntraOpsWorkspace"
 #>
 function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
 
@@ -166,12 +166,12 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
 
                     if ($UserClassificationSource -eq "Object") {
                         # Get classification by custom security attribute of the privileged user
-                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $AssociatedPrivilegedUser.ObjectId } | Select-Object -Unique ObjectAdminTierLevelName)[0]
+                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -Unique ObjectAdminTierLevelName)[0]
                         $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
                     }
                     else {
                         # Get highest classification by assigned roles
-                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $AssociatedPrivilegedUser.ObjectId } | Select-Object -ExpandProperty Classification | Sort-Object AdminTierLevel | Select-Object AdminTierLevelName)[0]
+                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -ExpandProperty Classification | Sort-Object AdminTierLevel | Select-Object AdminTierLevelName)[0]
                         $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
                     }
 

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
@@ -28,15 +28,12 @@
 
 .EXAMPLE
     Save data of EntraOps Privileged EAM insights to WatchList in Microsoft Sentinel Workspace for correlation between work and privileged accounts.
-    Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists -AddtoWatchListTemplates "IdentityCorrelation" -SentinelSubscriptionId "3f72a077-c32a-423c-8503-41b93d3b0737" -SentinelResourceGroupName "EntraOpsResourceGroup" -SentinelWorkspaceName "EntraOpsWorkspace"
+    Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists -WatchListTemplates "IdentityCorrelation" -SentinelSubscriptionId "3f72a077-c32a-423c-8503-41b93d3b0737" -SentinelResourceGroupName "EntraOpsResourceGroup" -SentinelWorkspaceName "EntraOpsWorkspace"
 #>
 function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $false)]
-        [System.String]$TenantId = $TenantIdContext
-        ,
         [Parameter(Mandatory = $false)]
         [ValidateSet("Object", "RoleClassification")]
         [System.String]$UserClassificationSource = "RoleClassification"
@@ -59,10 +56,8 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
         ,
         [Parameter(Mandatory = $False)]
         [ValidateSet("None", "All", "VIPUsers", "HighValueAssets", "IdentityCorrelation")]
-        [object]$AddToWatchListTemplates = "All"
+        [object]$WatchListTemplates = "All"
     )
-
-    Set-AzContext -SubscriptionId $SentinelSubscriptionId -TenantId $TenantNameContext | Out-Null
 
     try {
         Import-Module "SentinelEnrichment" -ErrorAction Stop

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
@@ -166,12 +166,12 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
 
                     if ($UserClassificationSource -eq "Object") {
                         # Get classification by custom security attribute of the privileged user
-                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -Unique ObjectAdminTierLevelName)[0]
+                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $AssociatedPrivilegedUser.ObjectId } | Select-Object -Unique ObjectAdminTierLevelName)[0]
                         $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
                     }
                     else {
                         # Get highest classification by assigned roles
-                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $PrivilegedUser.ObjectId } | Select-Object -ExpandProperty Classification | Sort-Object AdminTierLevel | Select-Object AdminTierLevelName)[0]
+                        $Classification = ($Privileges | Where-Object { $_.ObjectId -eq $AssociatedPrivilegedUser.ObjectId } | Select-Object -ExpandProperty Classification | Sort-Object AdminTierLevel | Select-Object AdminTierLevelName)[0]
                         $Tags.Add($($Classification.AdminTierLevelName)) | Out-Null
                     }
 

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
@@ -137,7 +137,7 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
                 SubscriptionId    = $SentinelSubscriptionId
                 ResourceGroupName = $SentinelResourceGroupName
                 WorkspaceName     = $SentinelWorkspaceName
-                Identifiers       = $Tags
+                Identifiers       = @("EntraOps", "Automated Enrichment")
             }
             Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
         }
@@ -205,7 +205,7 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
                 SubscriptionId    = $SentinelSubscriptionId
                 ResourceGroupName = $SentinelResourceGroupName
                 WorkspaceName     = $SentinelWorkspaceName
-                Identifiers       = $Tags
+                Identifiers       = @("EntraOps", "Automated Enrichment")
             }
             Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
         }
@@ -301,7 +301,7 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
                 SubscriptionId    = $SentinelSubscriptionId
                 ResourceGroupName = $SentinelResourceGroupName
                 WorkspaceName     = $SentinelWorkspaceName
-                Identifiers       = $Tags
+                Identifiers       = @("EntraOps", "Automated Enrichment")
             }
             Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
         }

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists.ps1
@@ -137,6 +137,7 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
                 SubscriptionId    = $SentinelSubscriptionId
                 ResourceGroupName = $SentinelResourceGroupName
                 WorkspaceName     = $SentinelWorkspaceName
+                OverrideTags      = $true
                 Identifiers       = @("EntraOps", "Automated Enrichment")
             }
             Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
@@ -206,6 +207,7 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
                 ResourceGroupName = $SentinelResourceGroupName
                 WorkspaceName     = $SentinelWorkspaceName
                 Identifiers       = @("EntraOps", "Automated Enrichment")
+                OverrideTags      = $true
             }
             Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
         }
@@ -302,6 +304,7 @@ function Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists {
                 ResourceGroupName = $SentinelResourceGroupName
                 WorkspaceName     = $SentinelWorkspaceName
                 Identifiers       = @("EntraOps", "Automated Enrichment")
+                OverrideTags      = $true
             }
             Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
         }

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMJson.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMJson.ps1
@@ -24,62 +24,12 @@ function Save-EntraOpsPrivilegedEAMJson {
         [System.String]$ExportFolder = $DefaultFolderClassifiedEam
         ,
         [Parameter(Mandatory = $False)]
-        [ValidateSet("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
-        [Array]$RbacSystems = ("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")
     )
 
     Write-Output "Clearing cache before analyzing RBAC and classification data"
     Clear-EntraOpsCache
-
-    #region Azure
-    if ($RbacSystems -contains "Azure") {
-        $ExportFolder = "$($DefaultFolderClassifiedEam)/Azure"
-
-        if ((Test-Path -path "$($ExportFolder)")) {
-            Remove-Item "$($ExportFolder)" -Force -Recurse
-            New-Item "$($ExportFolder)" -ItemType Directory -Force
-        }
-        else {
-            New-Item "$($ExportFolder)" -ItemType Directory -Force
-        }
-        $EamAzure = Get-EntraOpsPrivilegedEamAzure
-        $EamAzure = $EamAzure | where-object { $null -ne $_.ObjectType -and $null -ne $_.ObjectId }
-        $EamAzure | Convertto-Json -Depth 10 | Out-File -Path "$($ExportFolder)/Azure.json"
-        foreach ($PrivilegedObject in $EamAzure) {
-            $ObjectType = $PrivilegedObject.ObjectType
-            $SingleJSONExportPath = "$($ExportFolder)/$ObjectType"
-            If (!(test-path $SingleJSONExportPath)) {
-                New-Item -ItemType Directory -Force -Path $SingleJSONExportPath
-            }
-            $PrivilegedObject | Convertto-Json -Depth 10 | Out-File -Path "$SingleJSONExportPath/$($PrivilegedObject.ObjectId).json" -Force
-        }
-    }
-    #endregion
-
-    #region Azure Billing
-    if ($RbacSystems -contains "AzureBilling") {
-        $ExportFolder = "$($DefaultFolderClassifiedEam)/AzureBilling"
-
-        if ((Test-Path -path "$($ExportFolder)")) {
-            Remove-Item "$($ExportFolder)" -Force -Recurse
-            New-Item "$($ExportFolder)" -ItemType Directory -Force
-        }
-        else {
-            New-Item "$($ExportFolder)" -ItemType Directory -Force
-        }
-        $EamAzureBilling = Get-EntraOpsPrivilegedEamAzureBilling -SampleMode $true -GlobalExclusion $false
-        $EamAzureBilling = $EamAzureBilling | where-object { $null -ne $_.ObjectType -and $null -ne $_.ObjectId }
-        $EamAzureBilling | Convertto-Json -Depth 10 | Out-File -Path "$($ExportFolder)/AzureBilling.json" -Force
-        foreach ($PrivilegedObject in $EamAzureBilling) {
-            $ObjectType = $PrivilegedObject.ObjectType
-            $SingleJSONExportPath = "$($ExportFolder)/$ObjectType"
-            If (!(test-path $SingleJSONExportPath)) {
-                New-Item -ItemType Directory -Force -Path $SingleJSONExportPath
-            }
-            $PrivilegedObject | Convertto-Json -Depth 10 | Out-File -Path "$SingleJSONExportPath/$($PrivilegedObject.ObjectId).json" -Force
-        }
-    }
-    #endregion
 
     #region Entra ID
     if ($RbacSystems -contains "EntraID") {

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMWatchLists.ps1
@@ -59,7 +59,7 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
         ,
         [Parameter(Mandatory = $False)]
         [ValidateSet("None", "All", "VIPUsers", "HighValueAssets", "IdentityCorrelation")]
-        [object]$AddToWatchListTemplates = "All"        
+        [object]$WatchListTemplates = "All"        
     )
 
     Install-EntraOpsRequiredModule -ModuleName SentinelEnrichment
@@ -155,12 +155,12 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
         }
     }
 
-    if ($AddToWatchListTemplates -ne "None") {
+    if ($WatchListTemplates -ne "None") {
         $Parameters = @{
             SentinelSubscriptionId    = $SentinelSubscriptionId
             SentinelResourceGroupName = $SentinelResourceGroupName
             SentinelWorkspaceName     = $SentinelWorkspaceName
-            AddToWatchListTemplates   = $AddToWatchListTemplates
+            WatchListTemplates        = $WatchListTemplates
             RbacSystems               = $RbacSystems 
 
         }

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMWatchLists.ps1
@@ -20,6 +20,12 @@
 .PARAMETER WatchListPrefix
     Prefix for all WatchLists wihich will be created by this cmldet. Default is EntraOps_.
 
+.PARAMETER WatchListTemplates
+    Type of WatchLists to be created. Default is None. Possible values are All, VIPUsers, HighValueAssets, IdentityCorrelation.
+
+.PARAMETER WatchListWorkloadIdentity
+    Type of WatchLists to be created. Default is None. Possible values are All, ManagedIdentityAssignedResourceId, WorkloadIdentityAttackPaths, WorkloadIdentityInfo, WorkloadIdentityRecommendations.
+
 .PARAMETER RbacSystems
     Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
 
@@ -59,11 +65,11 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
         ,
         [Parameter(Mandatory = $False)]
         [ValidateSet("None", "All", "VIPUsers", "HighValueAssets", "IdentityCorrelation")]
-        [object]$WatchListTemplates = "All"
+        [object]$WatchListTemplates = "None"
         ,
         [Parameter(Mandatory = $False)]
         [ValidateSet("None", "ManagedIdentityAssignedResourceId", "All", "WorkloadIdentityAttackPaths", "WorkloadIdentityInfo", "WorkloadIdentityRecommendations")]
-        [object]$WatchListWorkloadIdentity = "All"
+        [object]$WatchListWorkloadIdentity = "None"
     )
 
     Install-EntraOpsRequiredModule -ModuleName SentinelEnrichment
@@ -73,8 +79,7 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
 
         try {
             $Privileges = Get-Content -Path "$($ImportPath)/$($Rbac)/$($Rbac).json" -ErrorAction Stop | ConvertFrom-Json -Depth 10
-        }
-        catch {
+        } catch {
             Write-Warning "No information found for $Rbac in file $($ImportPath)/$($Rbac)/$($Rbac).json"
             continue
         }
@@ -109,8 +114,7 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
                     $RoleAssignment | Add-Member -MemberType NoteProperty -Name "Classification" -Value "$($RoleAssignment.Classification | ConvertTo-Json -Depth 10 -Compress -AsArray)" -Force
                     if ($null -eq $RoleAssignment.TransitiveByObjectId ) {
                         $RoleAssignment | Add-Member -MemberType NoteProperty -Name "UniqueId" -Value "$($RoleAssignment.RoleAssignmentId)_$($RoleAssignment.PrincipalId)" -Force
-                    }
-                    else {
+                    } else {
                         $RoleAssignment | Add-Member -MemberType NoteProperty -Name "UniqueId" -Value "$($RoleAssignment.RoleAssignmentId)_$($RoleAssignment.PrincipalId)_$($RoleAssignment.TransitiveByObjectId)" -Force
                     }
                     $TagValue = @("$($Rbac)", "Classification", "Automated Enrichment") | ConvertTo-Json -Depth 10 -Compress -AsArray
@@ -183,5 +187,5 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
 
         }
         Save-EntraOpsWorkloadIdentityEnrichmentWatchLists @Parameters
-    }    
+    }
 }

--- a/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMWatchLists.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Save-EntraOpsPrivilegedEAMWatchLists.ps1
@@ -5,13 +5,6 @@
 .DESCRIPTION
     Get information from EntraOps about classification based on Enterprise Access Model and save it as WatchList in Microsoft Sentinel.
 
-<#
-.SYNOPSIS
-    Wrapper function to save data of EntraOps Privileged EAM insights to custom table in Log Analytics or Sentinel Workspace.
-
-.DESCRIPTION
-    Wrapper function to save data of EntraOps Privileged EAM insights to custom table in Log Analytics or Sentinel Workspace.
-
 .PARAMETER ImportPath
     Folder where the classification files should be stored. Default is ./PrivilegedEAM.
 
@@ -63,6 +56,10 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
         [Parameter(Mandatory = $false)]
         [ValidateSet("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
         [object]$RbacSystems = ("Azure", "AzureBilling", "EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("None", "All", "VIPUsers", "HighValueAssets", "IdentityCorrelation")]
+        [object]$AddToWatchListTemplates = "All"        
     )
 
     Install-EntraOpsRequiredModule -ModuleName SentinelEnrichment
@@ -156,5 +153,17 @@ function Save-EntraOpsPrivilegedEAMWatchLists {
                 New-GkSeAzSentinelWatchlist @Parameters
             }
         }
+    }
+
+    if ($AddToWatchListTemplates -ne "None") {
+        $Parameters = @{
+            SentinelSubscriptionId    = $SentinelSubscriptionId
+            SentinelResourceGroupName = $SentinelResourceGroupName
+            SentinelWorkspaceName     = $SentinelWorkspaceName
+            AddToWatchListTemplates   = $AddToWatchListTemplates
+            RbacSystems               = $RbacSystems 
+
+        }
+        Save-EntraOpsPrivilegedEAMEnrichmentToWatchLists @Parameters
     }
 }

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedAdministrativeUnit.ps1
@@ -35,6 +35,11 @@ function Update-EntraOpsPrivilegedAdministrativeUnit {
         [Parameter(Mandatory = $False)]
         [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
         [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("None", "Selected", "All")]
+        [string]$RestrictedAuMode = "Selected" #Default value will not create RMAU for Tier0 and EntraID and Identity Governance RBACs
+
     )
 
     foreach ($RbacSystem in $RbacSystems) {

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedAdministrativeUnit.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Updates (Restricted Management) Administrative Units based on EntraOps classification.
+
+.DESCRIPTION
+    (Restricted Management) Administrative Units for the different Enterprise Access Levels will be updated based on the classification of EntraOps.
+    Objects will be assigned to the corresponding Administrative Units based on the classification.
+
+.PARAMETER ApplyToAccessTierLevel
+    Array of Access Tier Levels to be processed. Default is ControlPlane, ManagementPlane.
+
+.PARAMETER FilterObjectType
+    Array of object types to be processed. Default is User, Group. Service Principal and application objects are not supported to be assigned to AUs.
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.EXAMPLE
+    Update administrative units for EntraID, IdentityGovernance and ResourceApps RBAC systems with User and Group objectss
+    Update-EntraOpsPrivilegedAdministrativeUnit -RbacSystems ("EntraID", "IdentityGovernance") -FilterObjectType ("User", "Group") -RestrictedAUMode "Selected"
+#>
+
+function Update-EntraOpsPrivilegedAdministrativeUnit {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ControlPlane", "ManagementPlane")]
+        [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("User", "Group")]
+        [Array]$FilterObjectType = ("User", "Group")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement", "ResourceApps")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+    )
+
+    foreach ($RbacSystem in $RbacSystems) {
+
+        # Get EAM classification files
+        if ($RbacSystem -eq "EntraID") {
+            $ClassificationTemplateSubFolder = "AadResources"
+        }
+        elseif ($RbacSystem -eq "ResourceApps") {
+            $ClassificationTemplateSubFolder = "AppRoles"
+        }
+        else {
+            $ClassificationTemplateSubFolder = $RbacSystem
+        }
+        $Classification = "$DefaultFolderClassifiedEam/$RbacSystem/$($RbacSystem).json"
+        $ClassificationTemplates = "$DefaultFolderClassification/Templates/Classification_$($ClassificationTemplateSubFolder).json"
+
+        $PrivilegedEamClassificationFiles = @()
+        $PrivilegedEamClassificationFiles = Get-ChildItem -Path $ClassificationTemplates -Filter "*.json"
+        $PrivilegedEamClassifications = $PrivilegedEamClassificationFiles | foreach-object { Get-Content -Path $_.FullName | ConvertFrom-Json } | where-object { $_.EAMTierLevelName -in $ApplyToAccessTierLevel } | select-object -unique EAMTierLevelName, EAMTierLevelTagValue
+
+        #region Assign all principals in Privileged EAM to restricted AUs
+        $PrivilegedEam = @()
+        $PrivilegedEam += Get-ChildItem -Path $Classification | foreach-object { Get-Content $_.FullName -Filter "*.json" | ConvertFrom-Json }
+        $PrivilegedEam = $PrivilegedEam | Where-Object { $_.ObjectType -in $FilterObjectType }
+        $PrivilegedEamCount = ($PrivilegedEam | Where-Object { $null -eq $_.Classification }).count
+        if ($PrivilegedEamCount -gt 0) { Write-Warning "Numbers of objects without classification: $PrivilegedEamCount" }
+        $PrivilegedEamClassifiedObjects = $PrivilegedEam | where-object { $_.Classification.AdminTierLevel -notcontains $null -and $_.RoleSystem -eq $RbacSystem }
+
+        foreach ($TierLevel in $PrivilegedEamClassifications) {
+            $AdminUnitId = $null
+            $AdminUnitName = "Tier" + $TierLevel.EAMTierLevelTagValue + "-" + $TierLevel.EAMTierLevelName + "." + $RbacSystem
+            $AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$AdminUnitName'" -DisableCache).id
+            if ($null -eq $AdminUnitId) {
+                throw "Can not find any AU with the name $AdminUnitName"
+            }
+            $EntraOpsPrivilegedObjects = @()
+            $EntraOpsPrivilegedObjects = ($PrivilegedEamClassifiedObjects | Where-Object { $_.Classification.AdminTierLevel -contains $TierLevel.EAMTierLevelTagValue -and $_.Classification.AdminTierLevelName -contains $TierLevel.EAMTierLevelName -and $_.RoleSystem -eq $RbacSystem })
+            $CurrentAdminUnitMembers = @()
+            $CurrentAdminUnitMembers = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits/$($AdminUnitId)/members" -OutputType PSObject -DisableCache)
+
+            # Check if AU members already exists for sync, or just adding new items
+            if ($Null -eq $CurrentAdminUnitMembers.Id) {
+                # Add all members to the AU
+                $EntraOpsPrivilegedObjects | foreach-object {
+
+                    $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method Get -Uri "/beta/directoryObjects/$($_.ObjectId)" -OutputType PSObject
+                    $AdminUnitMemberObjectType = $AdminUnitMember.'@odata.type'.Replace('#microsoft.graph.', '')
+                    Write-Host "Adding $($AdminUnitMemberObjectType) $($AdminUnitMember.displayName) to $($AdminUnitName)"
+
+                    $OdataBody = @{
+                        '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)"
+                    } | ConvertTo-Json
+                    Invoke-EntraOpsMsGraphQuery -Method "POST" -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/`$ref" -DisableCache -Body $OdataBody -OutputType PSObject
+                }
+            }
+            else {
+                # Add or remove members from the AU which are not in scope of classification
+                $Diff = Compare-Object $EntraOpsPrivilegedObjects.ObjectId $CurrentAdminUnitMembers.Id
+                $Diff | ForEach-Object {
+                    if ($_.SideIndicator -eq "=>") {
+                        $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method "GET" -Uri "/beta/directoryObjects/$($_.InputObject)" -OutputType PSObject
+                        Write-Host "Removing $($AdminUnitMember.displayName) from $($AdminUnitName)"
+                        try {
+                            Invoke-EntraOpsMsGraphQuery -Method "DELETE" -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/$($_.InputObject)/`$ref" -OutputType PSObject
+                        }
+                        catch {
+                            Write-Warning "Removal for $($AdminUnitMember.displayName) has been failed!"
+                        }
+
+                    }
+                    elseif ($_.SideIndicator -eq "<=") {
+                        try {
+                            $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method GET -Uri "/beta/directoryObjects/$($_.InputObject)" -DisableCache -OutputType PSObject
+                            Write-Host "Adding $($AdminUnitMember.displayName) to $($AdminUnitName)"
+
+                            $OdataBody = @{
+                                '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)"
+                            } | ConvertTo-Json
+
+                            Invoke-EntraOpsMsGraphQuery -Method "POST" -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/`$ref" -DisableCache -Body $OdataBody -OutputType PSObject
+                        }
+                        catch {
+                            Write-Warning "Can not add $($AdminUnitMember.displayName)"
+                            Write-Host $_.Exception
+                        }
+                    }
+                }
+            }
+        }
+        #endregion
+    }
+}

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+    Update membership on security groups based on EntraOps classification which can be used for targeting Conditional Access policies.
+
+.DESCRIPTION
+    Security Groups for the different Enterprise Access Levels will be updated based on the classification of EntraOps.
+    Objects will be assigned to the corresponding Administrative Units based on the classification.
+    This security groups can be used for targeting Conditional Access policies.
+
+.PARAMETER ApplyToAccessTierLevel
+    Array of Access Tier Levels to be processed. Default is ControlPlane, ManagementPlane.
+
+.PARAMETER FilterObjectType
+    Array of object types to be processed. Default is User, Group.
+
+.PARAMETER GroupPrefix
+    String to define the prefix of the Conditional Access Inclusion Groups. Default is "sug_Entra.CA.IncludeUsers.PrivilegedAccounts."
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.EXAMPLE
+    Update Conditional Access Target Groups for EntraID, IdentityGovernance and ResourceApps RBAC systems with assigned User and Group objects
+    Update-EntraOpsPrivilegedConditionalAccessGroup -GroupPrefix "sug_Entra.CA.IncludeUsers.PrivilegedAccounts." -RbacSystems ("EntraID", "IdentityGovernance")
+#>
+
+function Update-EntraOpsPrivilegedConditionalAccessGroup {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ControlPlane", "ManagementPlane")]
+        [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("User", "Group")]
+        [Array] $FilterObjectType = ("User", "Group")
+        ,
+        [Parameter(Mandatory = $False)]
+        [string]$GroupPrefix = "sug_Entra.CA.IncludeUsers.PrivilegedAccounts."
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+    )
+
+    foreach ($RbacSystem in $RbacSystems) {
+
+        $Classification = "$DefaultFolderClassifiedEam/$RbacSystem/$($RbacSystem).json"
+
+        #region Get principals from EAM classification files and filter out objects without classification and objects not related to the RBAC system or object type filter
+        $PrivilegedEam = @()
+        $PrivilegedEam += Get-ChildItem -Path $Classification | foreach-object { Get-Content $_.FullName -Filter "*.json" | ConvertFrom-Json }
+        $PrivilegedEam = $PrivilegedEam | Where-Object { $_.ObjectType -in $FilterObjectType }
+        $PrivilegedEamCount = ($PrivilegedEam | Where-Object { $null -eq $_.Classification }).count
+        if ($PrivilegedEamCount -gt 0) { Write-Warning "Numbers of objects without classification: $PrivilegedEamCount" }
+        $PrivilegedEamClassifiedObjects = $PrivilegedEam | where-object { $_.Classification.AdminTierLevel -notcontains $null -and $_.RoleSystem -eq $RbacSystem }
+
+        # Get all unique AdminTierLevels which needs to be iterated for assigning objects to Conditional Access Target Groups
+        $PrivilegedEamClassificationTierLevels = $PrivilegedEamClassifiedObjects | ForEach-Object {
+            $Classification = $_.Classification
+            $Classification | where-object { $_.AdminTierLevelName -in $ApplyToAccessTierLevel } | select-object -unique AdminTierLevel, AdminTierLevelName
+        }
+        $PrivilegedEamClassificationTierLevels = $PrivilegedEamClassificationTierLevels | select-object -unique AdminTierLevel, AdminTierLevelName
+        #endregion
+
+        #region Assign all principals in Privileged EAM to Conditional Access Target Groups
+        foreach ($TierLevel in $PrivilegedEamClassificationTierLevels) {
+            $GroupName = "$GroupPrefix" + $TierLevel.AdminTierLevelName + "." + $($RbacSystem)
+            $GroupId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/v1.0/groups?`$filter=DisplayName eq '$GroupName'" -OutputType PSObject -DisableCache).id
+            $PrivilegedObjects = @()
+            $PrivilegedObjects = ($PrivilegedEamClassifiedObjects | Where-Object { $_.Classification.AdminTierLevelName -contains $TierLevel.AdminTierLevelName -and $_.RoleSystem -eq $RbacSystem })
+            $CurrentGroupMembers = @()
+            $CurrentGroupMembers = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/groups/$($GroupId)/members" -OutputType PSObject -DisableCache)
+
+            # Check if group members already exists for sync, or just adding new items
+            if ($Null -eq $CurrentGroupMembers.Id) {
+                $PrivilegedObjects | foreach-object {
+                    $GroupMember = Invoke-EntraOpsMsGraphQuery -Method GET -Uri "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)" -DisableCache -OutputType PSObject
+                    Write-Host "Adding $($GroupMember.displayName) to $($GroupName)"
+
+                    $OdataBody = @{
+                        '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)"
+                    } | ConvertTo-Json
+
+                    try {
+                        Invoke-EntraOpsMsGraphQuery -Method POST -Uri "/beta/groups/$($GroupId)/members/`$ref" -Body $OdataBody -OutputType PSObject
+                    }
+                    catch {
+                        Write-Warning "Failed to add $($GroupMember.displayName) to $($GroupName). Error: $_"
+                    }
+                }
+            }
+            else {
+                Compare-Object $PrivilegedEamClassifiedObjects.ObjectId $CurrentGroupMembers.Id | ForEach-Object {
+                    if ($_.SideIndicator -eq "=>") {
+                        Write-Warning "$($_.InputObject) will be removed from $($GroupName)!"
+                        Invoke-EntraOpsMsGraphQuery -Method DELETE -Uri "/beta/groups/$($GroupId)/members/$($_.InputObject)/`$ref" -OutputType PSObject
+                    }
+                    elseif ($_.SideIndicator -eq "<=") {
+                        $GroupMember = Invoke-MgGraphRequest -Method GET -Uri "/beta/directoryObjects/$($_.InputObject)" -OutputType PSObject
+                        Write-Host "Adding $($GroupMember.displayName) to $($GroupName)"
+
+                        $OdataBody = @{
+                            '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)"
+                        } | ConvertTo-Json
+
+                        Invoke-MgGraphRequest -Method POST -Uri "/beta/groups/$($GroupId)/members/`$ref" -Body $OdataBody -OutputType PSObject
+                    }
+                }
+            }
+        }
+        #endregion
+    }
+}

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
@@ -42,6 +42,9 @@ function Update-EntraOpsPrivilegedConditionalAccessGroup {
         [Parameter(Mandatory = $False)]
         [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
         [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+        ,
+        [Parameter(Mandatory = $false)]
+        [String]$AdminUnitName        
     )
 
     foreach ($RbacSystem in $RbacSystems) {

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
@@ -57,7 +57,7 @@ function Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
 
         # Get Administrative Unit Id for related tier level
         $AdminUnitId = $null
-        $AdminUnitName = "Tier" + $TierLevel.AdminTierLevel + "-" + $TierLevel.AdminTierLevelName + ".UnprotectedAccounts"
+        $AdminUnitName = "Tier" + $TierLevel.AdminTierLevel + "-" + $TierLevel.AdminTierLevelName + ".UnprotectedObjects"
         $AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$AdminUnitName'" -DisableCache -OutputType PSObject).id
 
         if ($null -eq $AdminUnitId) {

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
@@ -75,7 +75,7 @@ function Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
 
                 $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method Get -Uri "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)" -OutputType PSObject -DisableCache
                 $AdminUnitMemberObjectType = $AdminUnitMember.'@odata.type'.Replace('#microsoft.graph.', '')
-                Write-Host "Adding $($AdminUnitMemberObjectType) $($AdminUnitMember.displayName) to $($AdminUnitName)"
+                Write-Verbose "Adding $($AdminUnitMemberObjectType) $($AdminUnitMember.displayName) to $($AdminUnitName)"
 
                 $OdataBody = @{
                     '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)"
@@ -113,7 +113,7 @@ function Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
                 if ($_.SideIndicator -eq "=>") {
 
                     $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method GET -Uri "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)" -OutputType PSObject
-                    Write-Host "Removing $($AdminUnitMember.displayName) from $($AdminUnitName)"
+                    Write-Verbose "Removing $($AdminUnitMember.displayName) from $($AdminUnitName)"
                     try {
                         Invoke-EntraOpsMsGraphQuery -Method DELETE -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/$($_.InputObject)/`$ref" -OutputType PSObject
                     }
@@ -125,7 +125,7 @@ function Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
                 elseif ($_.SideIndicator -eq "<=") {
                     try {
                         $AdminUnitMember = (Get-MgDirectoryObject -DirectoryObjectId $_.InputObject)
-                        Write-Host "Adding $($AdminUnitMember.displayName) to $($AdminUnitName)"
+                        Write-Verbose "Adding $($AdminUnitMember.displayName) to $($AdminUnitName)"
 
                         $OdataBody = @{
                             '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)"

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+    Add privileged users without any protection (by role-assignable groups, assigned directory role or existing RMAU membership) to an Restricted Management Administrative Units to avoid delegated management by lower privileged user.
+
+.DESCRIPTION
+    Add privileged users without any protection (by role-assignable groups, assigned directory role or existing RMAU membership) to an Restricted Management Administrative Units to avoid delegated management by lower privileged user.
+
+.PARAMETER ApplyToAccessTierLevel
+    Array of Access Tier Levels to be processed. Default is ControlPlane, ManagementPlane.
+
+.PARAMETER FilterObjectType
+    Array of object types to be processed. Default is User, Group. Service Principal and application objects are not supported to be protected by RMAU.
+
+.PARAMETER RbacSystems
+    Array of RBAC systems to be processed. Default is Azure, AzureBilling, EntraID, IdentityGovernance, DeviceManagement, ResourceApps.
+
+.EXAMPLE
+    Assign privileged users without any protection but privileges in RBAC Systems "IdentityGovernance" to Restricted Management Administrative Units
+    Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit -RbacSystems ("IdentityGovernance")
+#>
+
+function Update-EntraOpsPrivilegedUnprotectedAdministrativeUnit {
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ControlPlane", "ManagementPlane")]
+        [Array]$ApplyToAccessTierLevel = ("ControlPlane", "ManagementPlane")
+        ,
+
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("User", "Group")]
+        [Array]$FilterObjectType = ("User", "Group")
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("EntraID", "IdentityGovernance", "DeviceManagement")]
+        [Array]$RbacSystems = ("EntraID", "IdentityGovernance")
+    )
+
+    # Get all privileged EAM objects
+    $PrivilegedEamObjects = foreach ($RbacSystem in $RbacSystems) {
+        Get-Content "$DefaultFolderClassifiedEam/$RbacSystem/$($RbacSystem).json" | ConvertFrom-Json
+    }
+
+    # Get all privileged EAM objects without any restricted management and their tier levels
+    $UnprotectedPrivilegedUser = $PrivilegedEamObjects | Where-Object { $_.RestrictedManagementByRAG -ne $True -and $_.RestrictedManagementByAadRole -ne $True -and $_.RestrictedManagementByRMAU -ne $True -and $_.ObjectType -in $FilterObjectType }
+
+    # Get all unique AdminTierLevels which needs to be iterated for assigning objects to Conditional Access Target Groups
+    $PrivilegedEamClassificationTierLevels = $UnprotectedPrivilegedUser | ForEach-Object {
+        $Classification = $_.Classification
+        $Classification | where-object { $_.AdminTierLevelName -in $ApplyToAccessTierLevel } | select-object -unique AdminTierLevel, AdminTierLevelName
+    }
+    $PrivilegedEamTierLevels = $PrivilegedEamClassificationTierLevels | select-object -unique AdminTierLevel, AdminTierLevelName
+
+    #region Assign all unprotected principals in Privileged EAM to restricted AUs or remove from RMAU if no longer privileged
+    foreach ($TierLevel in $PrivilegedEamTierLevels) {
+
+        # Get Administrative Unit Id for related tier level
+        $AdminUnitId = $null
+        $AdminUnitName = "Tier" + $TierLevel.AdminTierLevel + "-" + $TierLevel.AdminTierLevelName + ".UnprotectedAccounts"
+        $AdminUnitId = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits?`$filter=DisplayName eq '$AdminUnitName'" -DisableCache -OutputType PSObject).id
+
+        if ($null -eq $AdminUnitId) {
+            throw "Can not find any AU with the name $AdminUnitName! Error: $_"
+        }
+
+        # Get privileged object for related tier level
+        $UnprotectedPrivilegedUserOnTierLevel = ($UnprotectedPrivilegedUser | Where-Object { $_.Classification.AdminTierLevel -contains $TierLevel.AdminTierLevel -and $_.Classification.AdminTierLevelName -contains $TierLevel.AdminTierLevelName })
+        $CurrentAdminUnitMembers = @()
+        $CurrentAdminUnitMembers = (Invoke-EntraOpsMsGraphQuery -Method "GET" -Body $Body -Uri "/beta/administrativeUnits/$($AdminUnitId)/members" -OutputType PSObject -DisableCache)
+
+        # Check if AU members already exists
+        if ($null -eq $CurrentAdminUnitMembers.Id) {
+            $UnprotectedPrivilegedUserOnTierLevel | foreach-object {
+
+                $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method Get -Uri "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)" -OutputType PSObject -DisableCache
+                $AdminUnitMemberObjectType = $AdminUnitMember.'@odata.type'.Replace('#microsoft.graph.', '')
+                Write-Host "Adding $($AdminUnitMemberObjectType) $($AdminUnitMember.displayName) to $($AdminUnitName)"
+
+                $OdataBody = @{
+                    '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.ObjectId)"
+                } | ConvertTo-Json
+
+                Invoke-EntraOpsMsGraphQuery -Method "POST" -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/`$ref" -Body $OdataBody -OutputType PSObject
+            }
+        }
+        elseif ($null -eq $UnprotectedPrivilegedUserOnTierLevel) {
+
+            # Keep user in RMAU if no other RMAU is protecting the user or user is no longer privileged
+            $CurrentAdminUnitMembers | ForEach-Object {
+
+                $AssignmentsToAUs = (Invoke-EntraOpsMsGraphQuery -Uri "/beta/users/$($_.id)/memberOf/Microsoft.Graph.AdministrativeUnit" -OutputType PSObject -DisableCache).value
+                $AssignmentsToOtherRMAUs = $AssignmentsToAUs | Where-Object { $_.isMemberManagementRestricted -eq $True -and $_.id -ne $AdminUnitId }
+
+                if ($null -ne $AssignmentsToOtherRMAUs -or $_.id -notin $($PrivilegedEamObjects.ObjectId)) {
+                    $CurrentAdminUnitMembers | ForEach-Object {
+                        try {
+                            $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method GET -Uri "/beta/directoryObjects/$($_.Id)" -OutputType PSObject -DisableCache
+                            Invoke-EntraOpsMsGraphQuery -Method DELETE -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/$($_.Id)/`$ref" -OutputType PSObject -DisableCache
+                        }
+                        catch {
+                            Write-Warning "Removal for $($AdminUnitMember.displayName) has been failed!"
+                        }
+                    }
+                }
+                else {
+                    Write-Warning "Object $($AdminUnitMember.displayName) will keep in RMAU because of missing protection by regular RMAU!"
+                }
+            }
+        }
+        else {
+            Compare-Object $UnprotectedPrivilegedUserOnTierLevel.ObjectId $CurrentAdminUnitMembers.Id | ForEach-Object {
+                if ($_.SideIndicator -eq "=>") {
+
+                    $AdminUnitMember = Invoke-EntraOpsMsGraphQuery -Method GET -Uri "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)" -OutputType PSObject
+                    Write-Host "Removing $($AdminUnitMember.displayName) from $($AdminUnitName)"
+                    try {
+                        Invoke-EntraOpsMsGraphQuery -Method DELETE -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/$($_.InputObject)/`$ref" -OutputType PSObject
+                    }
+                    catch {
+                        Write-Warning "Removal for $($AdminUnitMember.displayName) has been failed!"
+                    }
+
+                }
+                elseif ($_.SideIndicator -eq "<=") {
+                    try {
+                        $AdminUnitMember = (Get-MgDirectoryObject -DirectoryObjectId $_.InputObject)
+                        Write-Host "Adding $($AdminUnitMember.displayName) to $($AdminUnitName)"
+
+                        $OdataBody = @{
+                            '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)"
+                        } | ConvertTo-Json
+
+                        Invoke-EntraOpsMsGraphQuery -Method POST -Uri "/beta/administrativeUnits/$($AdminUnitId)/members/`$ref" -Body $OdataBody -OutputType PSObject
+                    }
+                    catch {
+                        Write-Warning "Duplicated entry for $($AdminUnitMember.displayName)"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/EntraOps/Public/ServicePrincipals/Get-EntraOpsManagedIdentityAssignments.ps1
+++ b/EntraOps/Public/ServicePrincipals/Get-EntraOpsManagedIdentityAssignments.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Get information of Managed Identities and their assignments to Azure Resources.
+
+.DESCRIPTION
+    Get information of Managed Identities and their assignments to Azure Resources.
+
+.EXAMPLE
+    Get a list of all assignments of System- and User-Assigned Managed Identities to Azure Resources
+    Get-EntraOpsManagedIdentityAssignments
+#>
+function Get-EntraOpsManagedIdentityAssignments {
+
+    $Query = "
+    resources
+    | where identity has 'SystemAssigned' or type == 'microsoft.managedidentity/userassignedidentities'
+    | extend IdentityType = iff(type == 'microsoft.managedidentity/userassignedidentities', 'UserAssigned', 'SystemAssigned')
+    | extend ObjectId = iff(IdentityType == 'SystemAssigned', tostring(identity.principalId), tostring(properties.principalId))
+    | project ObjectId, ResourceId = tostring(tolower(id)), ResourceName = name, ResourceType = type, ResourceTags = tags, ResourceTenantId = tenantId, IdentityType
+    | join kind=leftouter (resources
+    | where identity.type has 'UserAssigned'
+    | mv-expand parse_json(identity.userAssignedIdentities)
+    | extend ResourceId = tostring(tolower(bag_keys(identity_userAssignedIdentities)[0]))
+    | project ResourceId, AssignedResourceId = id
+    ) on ResourceId
+    | project-away ResourceId1
+    | extend AssociatedWorkloadId = iff(IdentityType == 'SystemAssigned', ResourceId, AssignedResourceId)
+    | summarize AssociatedWorkloadId=make_set(AssociatedWorkloadId) by ObjectId, ResourceId, ResourceType, ResourceTenantId, IdentityType
+    "
+    
+    $AssignedManagedIdentities = Invoke-EntraOpsAzGraphQuery -KqlQuery $Query
+    return $AssignedManagedIdentities
+}

--- a/EntraOps/Public/ServicePrincipals/Get-EntraOpsWorkloadIdentityAttackPaths.ps1
+++ b/EntraOps/Public/ServicePrincipals/Get-EntraOpsWorkloadIdentityAttackPaths.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+    Get information of Attack Paths in Microsoft Defender for Cloud CSPM.
+
+.DESCRIPTION
+    Get information of Attack Paths including entity types of Service Principal and Managed Identity in Microsoft Defender for Cloud CSPM.
+
+.EXAMPLE
+    Get a list of all assignments of Attack Paths in Microsoft Defender for Cloud CSPM
+    Get-EntraOpsManagedIdentityAssignments
+#>
+function Get-EntraOpsWorkloadIdentityAttackPaths {
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("PSCustomObject", "WatchList")]
+    [string]$OutputType = "PSCustomObject"
+    ,    
+
+    $Query = 'securityresources
+    | where type == "microsoft.security/attackpaths"
+    | extend AttackPathDisplayName = tostring(properties["displayName"])
+    | mvexpand (properties.graphComponent.entities)
+    | extend Entity = parse_json(properties_graphComponent_entities)
+    | extend EntityId = (Entity.entityIdentifiers.principalOid)
+    | extend EntityType = (Entity.entityType)
+    | where EntityType == "serviceprincipal" or EntityType == "managedidentity"
+    | project id, AttackPathDisplayName, EntityId, EntityType, Description = tostring(properties["description"]), RiskFactors = tostring(properties["riskFactors"]), MitreTtp = tostring(properties["mITRETacticsAndTechniques"]), AttackStory = tostring(properties["attackStory"]), RiskLevel = tostring(properties["riskLevel"]), Target = tostring(properties["target"])'
+
+    $AttackPathResults = Invoke-EntraOpsAzGraphQuery -KqlQuery $Query
+    $WorkloadIdentityAttackPaths = foreach ($AttackPath in $AttackPathResults) {
+
+        if ($OutputType -eq "WatchList") {
+            $AttackPath.MitreTtp = $AttackPath.MitreTtp | ConvertFrom-Json -Depth 10 | ConvertTo-Json -Compress
+            $AttackPath.Target = $AttackPath.Target | ConvertFrom-Json -Depth 10 | ConvertTo-Json -Compress
+        }
+        else {
+            $AttackPath.MitreTtp = $AttackPath.MitreTtp | ConvertFrom-Json -Depth 10
+            $AttackPath.Target = $AttackPath.Target | ConvertFrom-Json -Depth 10
+        }
+
+        [PSCustomObject]@{
+            'AttackPathId'          = $AttackPath.Id
+            'AttackPathDisplayName' = $AttackPath.AttackPathDisplayName
+            'AttackStory'           = $AttackPath.AttackStory
+            'EntityId'              = $AttackPath.EntityId
+            'EntityType'            = $AttackPath.EntityType
+            'Description'           = $AttackPath.Description
+            'RiskFactors'           = $AttackPath.RiskFactors
+            'RiskLevel'             = $AttackPath.RiskLevel
+            'MitreTtp'              = $AttackPath.MitreTtp
+            'Target'                = $AttackPath.Target
+        }
+    }
+    return $WorkloadIdentityAttackPaths
+}

--- a/EntraOps/Public/ServicePrincipals/Get-EntraOpsWorkloadIdentityInfo.ps1
+++ b/EntraOps/Public/ServicePrincipals/Get-EntraOpsWorkloadIdentityInfo.ps1
@@ -24,20 +24,21 @@ function Get-EntraOpsWorkloadIdentityInfo {
     $ErrorActionPreference = "Stop"
 
     #region New watchlist items
-    $NewWatchlistItems = New-Object System.Collections.ArrayList
+    $NewWatchlistItems = [System.Collections.Concurrent.ConcurrentBag[psobject]]::new()
     Write-Verbose "Query tenant service principals - https://graph.microsoft.com/v1.0/serviceprincipals"
-    $ServicePrincipals = Invoke-EntraOpsMsGraphQuery -Uri "/v1.0/serviceprincipals"
+    $ServicePrincipals = Invoke-GkSeMgGraphRequest -Uri "https://graph.microsoft.com/v1.0/serviceprincipals"
 
     Write-Verbose "Query tenant applications - https://graph.microsoft.com/v1.0/applications"
-    $Applications = Invoke-EntraOpsMsGraphQuery -Uri "/v1.0/applications"
+    $Applications = Invoke-GkSeMgGraphRequest -Uri "https://graph.microsoft.com/v1.0/applications"
 
     Write-Verbose "Query directory role templates for mapping ID to name and further details"
-    $DirectoryRoleDefinitions = Invoke-EntraOpsMsGraphQuery -Uri "/beta/roleManagement/directory/roleDefinitions" | select-object displayName, templateId, isPrivileged, isBuiltin
+    $DirectoryRoleDefinitions = Invoke-GkSeMgGraphRequest -Uri "https://graph.microsoft.com/beta/roleManagement/directory/roleDefinitions" | Select-Object displayName, templateId, isPrivileged, isBuiltin
 
     Write-Verbose "Query app roles for mapping ID to name"
-    $SPObjectWithAppRoles = $ServicePrincipals | where-object { $_.AppRoles -ne $null }
+    $SPObjectWithAppRoles = $ServicePrincipals | Where-Object { $_.AppRoles -ne $null }
     $AppRoles = foreach ($SPObjectWithAppRole in $SPObjectWithAppRoles) {
-        $SPObjectWithAppRole.AppRoles | foreach-object {
+
+        $SPObjectWithAppRole.AppRoles | ForEach-Object {
 
             [PSCustomObject]@{
                 "AppId"                    = $SPObjectWithAppRole.appId
@@ -58,138 +59,10 @@ function Get-EntraOpsWorkloadIdentityInfo {
     }
 
     Write-Verbose "Get details for enrichment of service principals"
-    #endregion
-
     $ServicePrincipals | ForEach-Object -Parallel {
         $ServicePrincipal = $_
 
-        #region Copy of Graph Request because of parallel processing, import-module does not work yet
-        <#
-        .SYNOPSIS
-            Executing Query on Microsoft Graph API.
-
-        .DESCRIPTION
-            Wrapper to call Microsoft Graph API with pagination support to fetch all data and set default values.
-
-        .EXAMPLE
-            Get list of all transitive role assignments for a principal in Microsoft Entra ID by principalId and using ConsistencyLevel.
-            Invoke-EntraOpsMsGraphQuery -Uri "/beta/roleManagement/directory/transitiveRoleAssignments?$count=true&`$filter=principalId eq '$Principal'" -ConsistencyLevel "eventual"
-
-        .EXAMPLE
-            Get list of all role definitions in Microsoft Entra ID.
-            Invoke-EntraOpsMsGraphQuery -Uri "/beta/roleManagement/directory/roleDefinitions"
-        #>
-
-        function Invoke-EntraOpsMsGraphQuery {
-
-            param (
-                [parameter(Mandatory = $false)]
-                [string]$Method = 'GET',
-
-                [parameter(Mandatory = $true)]
-                [string]$Uri,
-
-                [parameter(Mandatory = $false)]
-                [string]$Body,
-
-                [parameter(Mandatory = $false)]
-                [string]$ConsistencyLevel,
-
-                [parameter(Mandatory = $false)]
-                [ValidateSet("HashTable", "PSObject", "HttpResponseMessage", "Json")]
-                [string]$OutputType = "HashTable"
-            )
-
-            # Format headers.
-            $HeaderParams = @{
-            }
-
-
-            # Check if the Uri is valid.
-            if ($Uri -like "/beta/*" -or $Uri -like "/v1.0/*") {
-                $Uri = "https://graph.microsoft.com$Uri"
-            }
-            elseif ($Uri -like "https://graph.microsoft.com/*") {
-            }
-            else {
-                throw "Invalid Graph URI: $($Uri)!"
-            }
-
-            # Add ConsistencyLevel if provided in parameter
-            if ($null -ne $ConsistencyLevel) {
-                $HeaderParams.Add('ConsistencyLevel', "$ConsistencyLevel")
-            }
-
-            # Create empty arrays to store the results
-            $QueryRequest = @()
-            $QueryResult = @()
-
-            if ($UseAzPwshOnly -eq $True) {
-                $AccessToken = (Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com" -AsSecureString).Token
-                $HeaderParams.Add('Authorization', "Bearer $($AccessToken | ConvertFrom-SecureString -AsPlainText)")
-
-                # Run the initial query to Graph API
-                if ($Method -eq 'GET') {
-                    $QueryRequest = Invoke-RestMethod -Headers $HeaderParams -Uri $Uri -Method $Method -ContentType "application/json" -ResponseHeadersVariable $ResponseMessage
-                }
-                else {
-                    $QueryRequest = Invoke-RestMethod -Headers $HeaderParams -Uri $Uri -Method $Method -ContentType "application/json" -Body $Body -ResponseHeadersVariable $ResponseMessage
-                }
-
-                # Add the initial query result to the result array
-                if ($QueryRequest.value) {
-                    $QueryResult += $QueryRequest.value
-                }
-                else {
-                    $QueryResult += $QueryRequest
-                }
-
-                # Run another query to fetch data until there are no pages left
-                if ($Uri -notlike "*`$top*") {
-                    while ($QueryRequest.'@odata.nextLink') {
-                        $QueryRequest = Invoke-RestMethod -Headers $HeaderParams -Uri $QueryRequest.'@odata.nextLink' -Method $Method -ContentType "application/json" -ResponseHeadersVariable $ResponseMessage
-                        $QueryResult += $QueryRequest.value
-                    }
-                }
-
-                switch ($OutputType) {
-                    HashTable { $QueryResult = $QueryResult | ConvertTo-Json -Depth 10 | ConvertFrom-Json -Depth 10 -AsHashtable }
-                    JSON { $QueryResult = $QueryResult | ConvertTo-Json -Depth 10 }
-                    PSObject { $QueryResult = $QueryResult }
-                    HttpResponseMessage { $QueryResult = $ResponseMessage }
-                }
-                $QueryResult
-
-            }
-            else {
-                # Run the initial query to Graph API
-                if ($Method -eq 'GET') {
-                    $QueryRequest = Invoke-EntraOpsMsGraphQuery -Headers $HeaderParams -Uri $Uri -Method $Method -ContentType "application/json" -OutputType $OutputType
-                }
-                else {
-                    $QueryRequest = Invoke-EntraOpsMsGraphQuery -Headers $HeaderParams -Uri $Uri -Method $Method -ContentType "application/json" -Body $Body -OutputType $OutputType
-                }
-
-                # Add the initial query result to the result array
-                if ($QueryRequest.value) {
-                    $QueryResult += $QueryRequest.value
-                }
-                else {
-                    $QueryResult += $QueryRequest
-                }
-
-                # Run another query to fetch data until there are no pages left
-                if ($Uri -notlike "*`$top*") {
-                    while ($QueryRequest.'@odata.nextLink') {
-                        $QueryRequest = Invoke-EntraOpsMsGraphQuery -Headers $HeaderParams -Uri $QueryRequest.'@odata.nextLink' -Method $Method -ContentType "application/json" -OutputType $OutputType
-                        $QueryResult += $QueryRequest.value
-                    }
-                }
-                $QueryResult
-            }
-        }
-        #endregion
-
+        #region Function to get tenant information
         function Get-AADTenantInformation {
             [CmdletBinding()]
             param (
@@ -228,12 +101,13 @@ function Get-EntraOpsWorkloadIdentityInfo {
             }
             $Tenant
         }
+        #endregion        
 
         try {
             Write-Verbose "Collecting data for $($ServicePrincipal.displayName)"
 
             # Custom Security Attributes
-            $ObjectCustomSec = (Invoke-EntraOpsMsGraphQuery -Method Get -Uri ("/beta/servicePrincipals/$($ServicePrincipal.Id)" + '?$select=customSecurityAttributes') -OutputType PSObject).customSecurityAttributes.$($CustomSecurityServicePrincipalAttribute)
+            $ObjectCustomSec = (Invoke-MgGraphRequest -Method Get -Uri ("https://graph.microsoft.com/beta/servicePrincipals/$($ServicePrincipal.Id)" + '?$select=customSecurityAttributes') -OutputType PSObject).customSecurityAttributes.$($CustomSecurityServicePrincipalAttribute)
             if ($Null -eq $ObjectCustomSec) {
                 $adminTier = "Unclassified"
                 $adminTierLevelName = "Unclassified"
@@ -258,18 +132,8 @@ function Get-EntraOpsWorkloadIdentityInfo {
             }
             else {
                 $AppOwnerTenant = Get-AADTenantInformation -AppTenantId $ServicePrincipal.AppOwnerOrganizationId
-            }
+            }           
 
-            # Associated Managed Identities
-            if ($ServicePrincipal.servicePrincipalType -eq "ManagedIdentity") {
-                $AppOwnerTenant = Get-AADTenantInformation -AppTenantId $TenantId
-                $Query = "resources | where (identity has 'SystemAssigned' or identity has 'UserAssigned') and (name == '$($Sp.displayName)' or identity contains '$($Sp.displayName)') | project id"
-                $AzGraphResult = Invoke-EntraOpsAzGraphQuery -KqlQuery $Query
-                $associatedWorkload = @()
-                $associatedWorkload += $AzGraphResult.id
-            }
-
-            # Service Princpal Details
             Write-Verbose "Query Application of ServicePrincipal `"$($ServicePrincipal.displayName)`""
             try {
                 $Application = $using:Applications | Where-Object appId -eq $ServicePrincipal.AppId
@@ -280,9 +144,10 @@ function Get-EntraOpsWorkloadIdentityInfo {
 
             Write-Verbose "Query Application Permissions of ServicePrincipal `"$($ServicePrincipal.displayName)`""
             try {
-                $SPRoleAssignments = (Invoke-EntraOpsMsGraphQuery -Uri "/v1.0/servicePrincipals/$($ServicePrincipal.id)/appRoleAssignments")
+                $AssignedAppRoles = New-Object System.Collections.ArrayList
+                $SPRoleAssignments = (Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/servicePrincipals/$($ServicePrincipal.id)/appRoleAssignments" -Verbose:$False)['value']
                 $SPRoleAssignments = foreach ($SPRoleAssignment in $SPRoleAssignments) {
-                    $AppRole = $using:AppRoles | where-object { $_.appRoleId -eq $SPRoleAssignment.appRoleId -and $_.ServicePrincipalObjectId -eq $SPRoleAssignment.resourceId }
+                    $AppRole = $using:AppRoles | Where-Object { $_.appRoleId -eq $SPRoleAssignment.appRoleId -and $_.ServicePrincipalObjectId -eq $SPRoleAssignment.resourceId }
 
                     [PSCustomObject]@{
                         "ResourceAppId"       = $AppRole.AppId
@@ -298,10 +163,44 @@ function Get-EntraOpsWorkloadIdentityInfo {
                 throw $_.Exception
             }
 
+            Write-Verbose "Query Ownership of ServicePrincipal `"$($ServicePrincipal.displayName)`""
+            try {
+                $ServicePrincipalOwnerships = New-Object System.Collections.ArrayList
+                $SpOwners = Invoke-GkSeMgGraphRequest -Uri "https://graph.microsoft.com/v1.0/serviceprincipals/$($ServicePrincipal.id)/owners" | Select-Object id
+                foreach ($SpOwner in $SpOwners) {
+                    $ServicePrincipalOwnerships.Add($SpOwner.id) | Out-Null
+                }
+                $ServicePrincipalOwnerships = $ServicePrincipalOwnerships | ConvertTo-Json -Compress -AsArray
+            }
+            catch {
+                Write-Error -Message $_.Exception
+                throw $_.Exception
+            }
+
+            if ($null -ne $Application.id) {
+                Write-Verbose "Query Ownership of Application `"$($ServicePrincipal.displayName)`""
+                try {
+                    $AppOwnerships = New-Object System.Collections.ArrayList
+                    $AppOwners = Invoke-GkSeMgGraphRequest -Uri "https://graph.microsoft.com/v1.0/applications/$($Application.Id)/owners" | Select-Object id
+                    foreach ($AppOwner in $AppOwners) {
+                        $AppOwnerships.Add($AppOwner.id) | Out-Null
+                    }
+                    $AppOwnerships = $AppOwnerships | ConvertTo-Json -Compress -AsArray
+                }
+                catch {
+                    Write-Error -Message $_.Exception
+                    throw $_.Exception
+                }
+            }
+
             Write-Verbose "Query Group Memberships of ServicePrincipal `"$($ServicePrincipal.displayName)`""
             try {
-                $TransitiveMemberOf = Invoke-EntraOpsMsGraphQuery -Uri "/v1.0/serviceprincipals/$($ServicePrincipal.id)/transitiveMemberOf" | Select-Object id, displayName, isAssignableToRole
-                $GroupMemberships = $TransitiveMemberOf | ConvertTo-Json -Compress -AsArray
+                $GroupMemberships = New-Object System.Collections.ArrayList
+                $TransitiveMemberOf = Invoke-GkSeMgGraphRequest -Uri "https://graph.microsoft.com/v1.0/serviceprincipals/$($ServicePrincipal.id)/transitiveMemberOf" | Select-Object id, displayName, isAssignableToRole
+                foreach ($GroupMembership in $TransitiveMemberOf) {
+                    $GroupMemberships.Add($GroupMembership) | Out-Null
+                }
+                $GroupMemberships = $GroupMemberships | ConvertTo-Json -Compress -AsArray
             }
             catch {
                 Write-Error -Message $_.Exception
@@ -310,9 +209,14 @@ function Get-EntraOpsWorkloadIdentityInfo {
 
             Write-Verbose "Query Directory Roles of ServicePrincipal `"$($ServicePrincipal.displayName)`""
             try {
-                $TransitiveRoleAssignments = (Invoke-EntraOpsMsGraphQuery -Method Get -ConsistencyLevel "eventual" -Uri "/beta/roleManagement/directory/transitiveRoleAssignments?`$count=true&`$filter=principalId eq '$($ServicePrincipal.Id)'")
+                $TransitiveRoleAssignments = New-Object System.Collections.ArrayList
+
+                $HeaderParams = @{
+                    'ConsistencyLevel' = "eventual"
+                }
+                $TransitiveRoleAssignments = (Invoke-MgGraphRequest -Method Get -Headers $HeaderParams -Uri "https://graph.microsoft.com/beta/roleManagement/directory/transitiveRoleAssignments?`$count=true&`$filter=principalId eq '$($ServicePrincipal.Id)'")['value']
                 $TransitiveRoleAssignments = foreach ($TransitiveRoleAssignment in $TransitiveRoleAssignments) {
-                    $RoleDefinition = $using:DirectoryRoleDefinitions | where-object { $_.templateid -eq $TransitiveRoleAssignment.roleDefinitionId }
+                    $RoleDefinition = $using:DirectoryRoleDefinitions | Where-Object { $_.templateid -eq $TransitiveRoleAssignment.roleDefinitionId }
 
                     [PSCustomObject]@{
                         "RoleDefinitionName" = $RoleDefinition.displayName
@@ -345,30 +249,33 @@ function Get-EntraOpsWorkloadIdentityInfo {
                     "CreatedDateTime"            = $ServicePrincipal.createdDateTime
                     "IsAccountEnabled"           = $ServicePrincipal.accountEnabled
                     "DisabledByMicrosoft"        = $ServicePrincipal.DisabledByMicrosoftStatus
-                    "AppOwnerTenantName"         = $AppOwnerTenant.TenantName
                     "VerifiedPublisher"          = $ServicePrincipal.VerifiedPublisher.DisplayName
-                    "PublisherName"              = $ServicePrincipal.PublisherName
+                    "PublisherName"              = $ServicePrincipal.PublisherName                    
+                    "AppOwnerTenantName"         = $AppOwnerTenant.TenantName                    
+                    "AppOwnerTenantId"           = $ServicePrincipal.AppOwnerOrganizationId
                     "IsFirstPartyApp"            = $IsFirstPartyApp
                     "ServicePrincipalType"       = $ServicePrincipal.servicePrincipalType
                     "SignInAudience"             = $ServicePrincipal.SignInAudience
                     "UserAssignmentRequired"     = $ServicePrincipal.appRoleAssignmentRequired
                     "ServiceManagementReference" = $ServicePrincipal.serviceManagementReference
+                    "ServicePrincipalOwners"     = $ServicePrincipalOwnerships
+                    "AppOwners"                  = $AppOwnerships
                     "AssignedAppRoles"           = $AssignedAppRoles
                     "GroupMembership"            = $GroupMemberships
                     "AssignedRoles"              = $AssignedRoles
                     "ObjectAdminTierLevel"       = $adminTier
-                    "ObjectAdminTierLevelName"   = $adminTierLevelName
-                    "AssociatedWorkload"         = $AssociatedWorkload | ConvertTo-Json -Compress
-                    "AssociatedService"          = $AssociatedService | ConvertTo-Json -Compress
-                    "Tags"                       = @("Entra ID", "Automated Enrichment") | ConvertTo-Json -Compress
+                    "ObjectAdminTierLevelName"   = $adminTierLevelName            
+                    "Tags"                       = @("Entra ID", "Automated Enrichment") | ConvertTo-Json -Compress -AsArray
                 }
                 ($using:NewWatchlistItems).Add( $CurrentItem ) | Out-Null
             }
         }
         catch {
+            Write-Warning "Could not add $($ServicePrincipal.displayName) - Error $($_.Exception)"
             Continue
         }
     }
+
     #endregion
-    return $NewWatchlistItems
+    return $NewWatchlistItems    
 }

--- a/EntraOps/Public/ServicePrincipals/Get-EntraOpsWorkloadIdentityInfo.ps1
+++ b/EntraOps/Public/ServicePrincipals/Get-EntraOpsWorkloadIdentityInfo.ps1
@@ -125,8 +125,8 @@ function Get-EntraOpsWorkloadIdentityInfo {
             $QueryResult = @()
 
             if ($UseAzPwshOnly -eq $True) {
-                $AccessToken = (Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com").Token
-                $HeaderParams.Add('Authorization', "Bearer $($AccessToken)")
+                $AccessToken = (Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com" -AsSecureString).Token
+                $HeaderParams.Add('Authorization', "Bearer $($AccessToken | ConvertFrom-SecureString -AsPlainText)")
 
                 # Run the initial query to Graph API
                 if ($Method -eq 'GET') {

--- a/EntraOps/Public/ServicePrincipals/Save-EntraOpsWorkloadIdentityEnrichmentWatchLists.ps1
+++ b/EntraOps/Public/ServicePrincipals/Save-EntraOpsWorkloadIdentityEnrichmentWatchLists.ps1
@@ -44,13 +44,12 @@ function Save-EntraOpsWorkloadIdentityEnrichmentWatchLists {
         ,
         [Parameter(Mandatory = $False)]
         [ValidateSet("ManagedIdentityAssignedResourceId", "All", "WorkloadIdentityAttackPaths", "WorkloadIdentityInfo", "WorkloadIdentityRecommendations")]
-        [object]$WatchLists = "All"
+        [object]$WatchLists = "None"
     )
 
     try {
         Import-Module "SentinelEnrichment" -ErrorAction Stop
-    }
-    catch {
+    } catch {
         throw "Issue to import SentinelEnrichment modul!"
     }
 
@@ -74,7 +73,7 @@ function Save-EntraOpsWorkloadIdentityEnrichmentWatchLists {
             $MiAssignedResourceIdWatchlistItems.Add( $MiAssignedResourceId ) | Out-Null
         }
 
-        if ( $null -ne $MiAssignedResourceIdWatchlistItems ) {
+        if ( ![string]::IsNullOrEmpty($MiAssignedResourceIdWatchlistItems) ) {
 
             $WatchListPath = Join-Path $PWD "$($WatchListName).csv"
             $MiAssignedResourceIdWatchlistItems | Export-Csv -Path $WatchListPath -NoTypeInformation -Encoding utf8 -Delimiter ","
@@ -201,4 +200,8 @@ function Save-EntraOpsWorkloadIdentityEnrichmentWatchLists {
         }
     }
     #endregion
+
+    if ($WatchLists -eq "None") {
+        Write-Warning 'No WatchList scope defined. Please define the target WatchLists by using "-WatchLists" parameter and choose between the following values/options: "All", "ManagedIdentityAssignedResourceId", "WorkloadIdentityAttackPaths", "WorkloadIdentityInfo", "WorkloadIdentityRecommendations"'
+    }
 }

--- a/EntraOps/Public/ServicePrincipals/Save-EntraOpsWorkloadIdentityEnrichmentWatchLists.ps1
+++ b/EntraOps/Public/ServicePrincipals/Save-EntraOpsWorkloadIdentityEnrichmentWatchLists.ps1
@@ -4,8 +4,8 @@
 
 .DESCRIPTION
     Get information of service principals to collect content and create the following watchlists:
-    - "ManagedIdentityAssignedResources" - List of resources with assigned Managed Identity
-    - "MdcAttackPaths" - List of attack paths in Microsoft Defender for Cloud for service principals and managed identities
+    - "ManagedIdentityAssignedResourceId" - List of resources with assigned Managed Identity
+    - "WorkloadIdentityAttackPaths" - List of attack paths in Microsoft Defender for Cloud for service principals and managed identities
     - "WorkloadIdentityInfo" - List of service principals with detailed information for Workload Identity
     - "WorkloadIdentityRecommendations" - List of recommendations for Workload Identity in Microsoft Entra ID
 
@@ -25,6 +25,7 @@
     Create all watchlists for Workload Identity Enrichment
     Save-EntaOpsWorkloadIdentityEnrichmentWatchLists -SentinelResourceGroupName "SentinelRG" -SentinelSubscriptionId "SentinelSubId" -SentinelWorkspaceName "SentinelWorkspace"
 #>
+
 function Save-EntraOpsWorkloadIdentityEnrichmentWatchLists {
 
     [CmdletBinding()]
@@ -40,9 +41,11 @@ function Save-EntraOpsWorkloadIdentityEnrichmentWatchLists {
         ,
         [Parameter(Mandatory = $True)]
         [System.String]$SentinelWorkspaceName
+        ,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet("ManagedIdentityAssignedResourceId", "All", "WorkloadIdentityAttackPaths", "WorkloadIdentityInfo", "WorkloadIdentityRecommendations")]
+        [object]$WatchLists = "All"
     )
-
-    Set-AzContext -SubscriptionId $SentinelSubscriptionId -TenantId $TenantId | Out-Null
 
     try {
         Import-Module "SentinelEnrichment" -ErrorAction Stop
@@ -51,120 +54,147 @@ function Save-EntraOpsWorkloadIdentityEnrichmentWatchLists {
         throw "Issue to import SentinelEnrichment modul!"
     }
 
-    $WatchListParameters = @{
-        SearchKey         = $null
-        DisplayName       = $null
-        NewWatchlistItems = ""
-        SubscriptionId    = $SentinelSubscriptionId
-        ResourceGroupName = $SentinelResourceGroupName
-        WorkspaceName     = $SentinelWorkspaceName
-        Identifiers       = @("Entra ID", "Automated Enrichment")
-    }
-
     #region Workload Identity Assignments
-    $WatchlistName = "ManagedIdentityAssignedResources"
-    function Get-WorkloadIdentityAssignment {
-        Write-Host "Collecting data for Managed Identity Assignments"
-        $Query = "resources | where identity has 'SystemAssigned' or identity has 'UserAssigned' | project id, name, type, tags, tenantId, identity"
-        $AzGraphResult = Invoke-EntraOpsAzGraphQuery -KqlQuery $Query
-        $AssignedManagedIdentity = $AzGraphResult | Where-Object { $_.tenantId -eq "$TenantId" } | foreach-object {
-            [PSCustomObject]@{
-                'ResourceId'       = $_.id
-                'ResourceName'     = $_.name
-                'ResourceType'     = $_.type
-                'ResourceTags'     = $_.tags | ConvertTo-Json -Depth 10 -Compress -AsArray
-                'ResourceTenantId' = $_.tenantId
-                'Identity'         = $_.identity | ConvertTo-Json -Depth 10 -Compress -AsArray
-            }
-        }
-        return $AssignedManagedIdentity
-    }
-    $ManagedIdentityAssignedResources = New-Object System.Collections.ArrayList
-    $ManagedIdentityAssignedResources = Get-WorkloadIdentityAssignment
-    Write-Verbose "Write information to watchlist: $WatchListName"
+    if ($WatchLists -eq "All" -or $WatchLists -contains "ManagedIdentityAssignedResourceId") {
+        $WatchListName = "ManagedIdentityAssignedResourceId"
+        $WatchListAlias = "ManagedIdentityAssignedResourceId"
 
-    if ( $null -ne $ManagedIdentityAssignedResources ) {
-        $WatchListParameters.SearchKey = "ResourceId"
-        $WatchListParameters.DisplayName = "ManagedIdentityAssignedResources"
-        $WatchListParameters.NewWatchlistItems = $ManagedIdentityAssignedResources
-        Edit-GkSeAzSentinelWatchlist @WatchListParameters
+        $MiAssignedResourceIds = Get-EntraOpsManagedIdentityAssignments
+        $MiAssignedResourceIdWatchlistItems = New-Object System.Collections.ArrayList
+
+        foreach ($MiAssignedResourceId in $MiAssignedResourceIds) {
+
+            $AssociatedWorkloadId = $MiAssignedResourceId.AssociatedWorkloadId | ConvertTo-Json -Depth 10 -Compress -AsArray
+            $MiAssignedResourceId | Add-Member -MemberType NoteProperty -Name "AssociatedWorkloadId" -Value $AssociatedWorkloadId -Force
+            $TagValue = @("EntraOps", "Automated Enrichment") | ConvertTo-Json -Depth 10 -Compress -AsArray
+            $MiAssignedResourceId | Add-Member -MemberType NoteProperty -Name "Tags" -Value $TagValue -Force
+
+            $MiAssignedResourceIdWatchlistItems.Add( $MiAssignedResourceId ) | Out-Null
+        }
+
+        if ( $null -ne $MiAssignedResourceIdWatchlistItems ) {
+            $SearchKey = "ObjectId"
+            $Parameters = @{
+                SearchKey         = $SearchKey
+                DisplayName       = $WatchListName
+                WatchListAlias    = $WatchListAlias
+                NewWatchlistItems = $MiAssignedResourceIdWatchlistItems
+                SubscriptionId    = $SentinelSubscriptionId
+                ResourceGroupName = $SentinelResourceGroupName
+                WorkspaceName     = $SentinelWorkspaceName
+                Identifiers       = $TagValue
+            }
+            Edit-GkSeAzSentinelWatchlist -Verbose @Parameters
+        }
     }
     #endregion
 
     #region WorkloadIdentityAttackPaths
-    $WatchlistName = "WorkloadIdentityAttackPaths"
-    $Query = 'securityresources
-    | where type == "microsoft.security/attackpaths"
-    | extend AttackPathDisplayName = tostring(properties["displayName"])
-    | mvexpand (properties.graphComponent.entities)
-    | extend Entity = parse_json(properties_graphComponent_entities)
-    | extend EntityType = (Entity.entityType)
-    | extend EntityName = (Entity.entityName)
-    | extend EntityResourceId = (Entity.entityIdentifiers.azureResourceId)
-    | where EntityType == "serviceprincipal" or EntityType == "managedidentity"
-    | project id, AttackPathDisplayName, EntityName, EntityType, Description = tostring(properties["description"]), RiskFactors = tostring(properties["riskFactors"]), MitreTtp = tostring(properties["mITRETacticsAndTechniques"]), AttackStory = tostring(properties["attackStory"]), RiskLevel = tostring(properties["riskLevel"]), Target = tostring(properties["target"])'
+    if ($WatchLists -eq "All" -or $WatchLists -contains "WorkloadIdentityAttackPaths") {
 
-    $WorkloadIdentityAttackPaths = New-Object System.Collections.ArrayList
-    $AttackPathResults = Invoke-EntraOpsAzGraphQuery -KqlQuery $Query
-    foreach ($AttackPath in $AttackPathResults) {
-        $CurrentItem = @{
-            'AttackPathId'          = $AttackPath.Id
-            'AttackPathDisplayName' = $AttackPath.AttackPathDisplayName
-            'AttackStory'           = $AttackPath.AttackStory
-            'EntityName'            = $AttackPath.EntityName
-            'EntityType'            = $AttackPath.EntityType
-            'Description'           = $AttackPath.Description
-            'RiskFactors'           = $AttackPath.RiskFactors
-            'RiskLevel'             = $AttackPath.RiskLevel
-            'MitreTtp'              = $AttackPath.MitreTtp
-            'Target'                = $AttackPath.Target | ConvertTo-Json -Compress -AsArray
-            'Tags'                  = @("WorkloadIdentityAttackPaths", "Automated Enrichment")
+        $WatchListName = "WorkloadIdentityAttackPaths"
+        $WatchListAlias = "WorkloadIdentityAttackPaths"
+        $SearchKey = "AttackPathId"
+
+        $WorkloadIdentityAttackPaths = Get-EntraOpsWorkloadIdentityAttackPaths
+        $WorkloadIdentityAttackPathsWatchlistItems = New-Object System.Collections.ArrayList
+
+        foreach ($WorkloadIdentityAttackPath in $WorkloadIdentityAttackPaths) {
+            $TagValue = @("EntraOps", "Automated Enrichment") | ConvertTo-Json -Depth 10 -Compress -AsArray
+            $WorkloadIdentity | Add-Member -MemberType NoteProperty -Name "Tags" -Value $TagValue -Force
+            $WorkloadIdentityAttackPathsWatchlistItems.Add( $WorkloadIdentityAttackPath ) | Out-Null
         }
-        $WorkloadIdentityAttackPaths.Add( $CurrentItem ) | Out-Null
-    }
 
-    Write-Verbose "Write information to watchlist: $WatchListName"
-    if ($WorkloadIdentityAttackPaths) {
-        $WatchListParameters.SearchKey = "AttackPathId"
-        $WatchListParameters.DisplayName = "WorkloadIdentityAttackPaths"
-        $WatchListParameters.NewWatchlistItems = $WorkloadIdentityAttackPaths
-        Edit-GkSeAzSentinelWatchlist @WatchListParameters
+        Write-Verbose "Write information to watchlist: $WatchListName"
+        if ( ![string]::IsNullOrEmpty($WorkloadIdentityAttackPathsWatchlistItems) ) {
+
+            $WatchListPath = Join-Path $PWD "$($WatchListName).csv"
+            $WorkloadIdentityRecommendationsWatchlistItems | Export-Csv -Path $WatchListPath -NoTypeInformation -Encoding utf8 -Delimiter ","
+            $Parameters = @{
+                WatchListFilePath        = $WatchListPath
+                DisplayName              = $WatchListName
+                itemsSearchKey           = $SearchKey
+                SubscriptionId           = $SentinelSubscriptionId
+                ResourceGroupName        = $SentinelResourceGroupName
+                WorkspaceName            = $SentinelWorkspaceName
+                DefaultDuration          = "P14D"
+                ReplaceExistingWatchlist = $true
+            }
+            New-GkSeAzSentinelWatchlist @Parameters
+            Remove-Item -Path $WatchListPath -Force
+        }
     }
     #endregion
 
     #region WorkloadIdentityInfo
-    $WatchlistName = "WorkloadIdentityInfo"
-    Write-Host "Collecting data for $WatchlistName and upload as Watchlist"
-    $WorkloadIdentityInfoItems = Get-EntraOpsWorkloadIdentityInfo
+    if ($WatchLists -eq "All" -or $WatchLists -contains "WorkloadIdentityInfo") {
 
-    Write-Verbose "Write information to watchlist: $WatchListName"
-    if ( $null -ne $WorkloadIdentityInfoItems ) {
-        $WatchListPath = Join-Path $PWD "$($WatchListName).csv"
-        $WorkloadIdentityInfoItems | Export-Csv -Path $WatchListPath -NoTypeInformation -Encoding utf8 -Delimiter ","
-        $Param2 = @{
-            WatchListFilePath        = $WatchListPath
-            DisplayName              = $WatchListName
-            itemsSearchKey           = "ServicePrincipalObjectId"
-            SubscriptionId           = $SentinelSubscriptionId
-            ResourceGroupName        = $SentinelResourceGroupName
-            WorkspaceName            = $SentinelWorkspaceName
-            DefaultDuration          = "P14D"
-            ReplaceExistingWatchlist = $true
+        $WatchListName = "WorkloadIdentityInfo"
+        $WatchListAlias = "WorkloadIdentityInfo"
+        $searchKey = "ServicePrincipalObjectId"
+
+        $WorkloadIdentityInfo = Get-EntraOpsWorkloadIdentityInfo
+        $WorkloadIdentityInfoWatchlistItems = New-Object System.Collections.ArrayList
+
+        foreach ($WorkloadIdentity in $WorkloadIdentityInfo) {
+            $TagValue = @("EntraOps", "Automated Enrichment") | ConvertTo-Json -Depth 10 -Compress -AsArray
+            $WorkloadIdentity | Add-Member -MemberType NoteProperty -Name "Tags" -Value $TagValue -Force
+            $WorkloadIdentityInfoWatchlistItems.Add( $WorkloadIdentity ) | Out-Null
         }
-        New-GkSeAzSentinelWatchlist @Param2
+
+        Write-Verbose "Write information to watchlist: $WatchListName"
+        if ( ![string]::IsNullOrEmpty($WorkloadIdentityInfoWatchlistItems) ) {
+            $WatchListPath = Join-Path $PWD "$($WatchListName).csv"
+            $WorkloadIdentityInfoWatchlistItems | Export-Csv -Path $WatchListPath -NoTypeInformation -Encoding utf8 -Delimiter ","
+            $Parameters = @{
+                WatchListFilePath        = $WatchListPath
+                DisplayName              = $WatchListName
+                itemsSearchKey           = $SearchKey
+                SubscriptionId           = $SentinelSubscriptionId
+                ResourceGroupName        = $SentinelResourceGroupName
+                WorkspaceName            = $SentinelWorkspaceName
+                DefaultDuration          = "P14D"
+                ReplaceExistingWatchlist = $true
+            }
+            New-GkSeAzSentinelWatchlist @Parameters
+            Remove-Item -Path $WatchListPath -Force
+        }
     }
     #endregion
 
     #region WorkloadIdentityRecommendation
-    Write-Host "Collecting data for Entra Recommendations and upload as Watchlist"
-    $WorkloadIdentityRecommendations = Get-EntraOpsWorkloadIdentityRecommendations
+    if ($WatchLists -eq "All" -or $WatchLists -contains "WorkloadIdentityRecommendations") {
 
-    Write-Verbose "Write information to watchlist: $WatchListName"
-    if ( $null -ne $WorkloadIdentityRecommendations ) {
-        $WatchListParameters.DisplayName = "WorkloadIdentityRecommendations"
-        $WatchListParameters.SearchKey = "ImpactedResourceIdentifier"
-        $WatchListParameters.NewWatchlistItems = $WorkloadIdentityRecommendations
-        Edit-GkSeAzSentinelWatchlist @WatchListParameters
+        $WatchListName = "WorkloadIdentityRecommendation"
+        $WatchListAlias = "WorkloadIdentityRecommendation"
+        $SearchKey = "ImpactedResourceIdentifier"
+
+        $WorkloadIdentityRecommendations = Get-EntraOpsWorkloadIdentityRecommendations
+        $WorkloadIdentityRecommendationsWatchlistItems = New-Object System.Collections.ArrayList
+
+        foreach ($WorkloadIdentityRecommendation in $WorkloadIdentityRecommendations) {
+            $TagValue = @("EntraOps", "Automated Enrichment") | ConvertTo-Json -Depth 10 -Compress -AsArray
+            $WorkloadIdentityRecommendation | Add-Member -MemberType NoteProperty -Name "Tags" -Value $TagValue -Force
+            $WorkloadIdentityRecommendationsWatchlistItems.Add( $WorkloadIdentityRecommendation ) | Out-Null
+        }
+
+        Write-Verbose "Write information to watchlist: $WatchListName"
+        if ( ![string]::IsNullOrEmpty($WorkloadIdentityRecommendationsWatchlistItems) ) {
+            $WatchListPath = Join-Path $PWD "$($WatchListName).csv"
+            $WorkloadIdentityRecommendationsWatchlistItems | Export-Csv -Path $WatchListPath -NoTypeInformation -Encoding utf8 -Delimiter ","
+            $Parameters = @{
+                WatchListFilePath        = $WatchListPath
+                DisplayName              = $WatchListName
+                itemsSearchKey           = $SearchKey
+                SubscriptionId           = $SentinelSubscriptionId
+                ResourceGroupName        = $SentinelResourceGroupName
+                WorkspaceName            = $SentinelWorkspaceName
+                DefaultDuration          = "P14D"
+                ReplaceExistingWatchlist = $true
+            }
+            New-GkSeAzSentinelWatchlist @Parameters
+            Remove-Item -Path $WatchListPath -Force
+        }
     }
     #endregion
 }

--- a/README.md
+++ b/README.md
@@ -515,11 +515,13 @@ The cmdlet can be executed interactively, and changes must be pushed to your rep
 Currently, there is also a workflow named "Update-EntraOps" which can be executed on demand or run on scheduled basis (defined in EntraOps.config) and updates the PowerShell module only.
 There are some restrictions to update workflows by another workflow which makes it hard to update the actions automatically.
 
+Regardless of the way to update EntraOps files, it could be required to update the service principals of EntraOps.
+Use `New-EntraOpsWorkloadIdentity` in combination of the parameter `-ExistingSpObjectId` and the object ID of the EntraOps service principal (Example: `New-EntraOpsWorkloadIdentity -AppDisplayName "EntraOps-CloudLab" -ExistingSpObjectId eca9154b-0d2a-4609-aa41-064eb317bfb3´). Ignore errors regarding existing API permissions or conflicts with existing roles.
+
+I recommend to remove and create a service principal but also re-create the EntraOps.config file if there should be any issues by updating EntraOps.
+
 ## Changelog
-
-Version 0.1
-
-Version 0.2
+Added features, changes or bug fixes can be found in the (GitHub issues)[https://github.com/Cloud-Architekt/EntraOps/issues] of the repository or in the (changelog)[./CHANGELOG.md].
 
 ## Disclaimer and License
 This tool is provided as-is, with no warranties.

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Use `New-EntraOpsWorkloadIdentity` in combination of the parameter `-ExistingSpO
 I recommend to remove and create a service principal but also re-create the EntraOps.config file if there should be any issues by updating EntraOps.
 
 ## Changelog
-Added features, changes or bug fixes can be found in the (GitHub issues)[https://github.com/Cloud-Architekt/EntraOps/issues] of the repository or in the (changelog)[./CHANGELOG.md].
+Added features, changes or bug fixes can be found in the [GitHub issues](https://github.com/Cloud-Architekt/EntraOps/issues) of the repository or in the [changelog](./CHANGELOG.md).
 
 ## Disclaimer and License
 This tool is provided as-is, with no warranties.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Integration to customize Control Plane scope automatically by critical assets in
 
 - 📊 Build reports or queries on your classified privileges to identify "tier breach" on Microsoft's Enterprise Access Model or privilege escalation paths. Workbook template to visualize classification data of role assignments (identified by EntraOps) and objects (by using custom security attributes)
 
-- 🛡️ Automated assignment of privileged assets in Conditional Access Groups and Restricted Management Administrative Units (RMAU) to protect high-privileged assets from lower privileges and apply strong Zero Trust policies. Privileged users and groups without existing restricted management by assignment to Administrative Unit (AU), role-assignable group or Entra ID role will be automatically covered by assignmend to a RMAU (named "UnprotectedAssets").
+- 🛡️ Automated assignment of privileged assets in Conditional Access Groups and Restricted Management Administrative Units (RMAU) to protect high-privileged assets from lower privileges and apply strong Zero Trust policies. Privileged users and groups without existing restricted management by assignment to Administrative Unit (AU), role-assignable group or Entra ID role will be automatically covered by assignmend to a RMAU (named "UnprotectedObjects").
 
 Currently the following RBAC systems are supported:
 - 🔑 Microsoft Entra roles

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Adjusted Control Plane Scope by using Restricted Management and Role Assignments](#adjusted-control-plane-scope-by-using-restricted-management-and-role-assignments)
   - [Why were this classification chosen for the role?](#why-were-this-classification-chosen-for-the-role)
   - [Update EntraOps PowerShell Module and CI/CD (GitHub Actions)](#update-entraops-powershell-module-and-cicd-github-actions)
+  - [Changelog](#changelog)
   - [Disclaimer and License](#disclaimer-and-license)
 
 ## Introduction
@@ -41,11 +42,11 @@ Integration to customize Control Plane scope automatically by critical assets in
 
 - 🔬 Ingest classification data with all details to custom table in Microsoft Sentinel/Log Analytics Workspace or WatchLists for hunting and enrichment. Including support for Sentinel WatchList templates (High Value Assets, VIP Users and Identity Correlation)
 
-- 🤖 Advanced WatchLists to get insights (relation between managed identities and Azure Resources) and information about security posture of Workload Identities by Microsoft Entra Recommendations and Microsoft Defender for Cloud CSPM.
+- 🤖 Advanced WatchLists to get insights (e.g., relation between managed identities and Azure Resources) but also information about security posture of Workload Identities by Microsoft Entra Recommendations and Microsoft Defender for Cloud CSPM (Attack Paths).
 
 - 📊 Build reports or queries on your classified privileges to identify "tier breach" on Microsoft's Enterprise Access Model or privilege escalation paths. Workbook template to visualize classification data of role assignments (identified by EntraOps) and objects (by using custom security attributes)
 
-- 🛡️ Automated assignment of privileged assets in Conditional Access Groups and Restricted Management Administrative Units to protect high-privileged assets from lower privileges and apply strong Zero Trust policies.
+- 🛡️ Automated assignment of privileged assets in Conditional Access Groups and Restricted Management Administrative Units (RMAU) to protect high-privileged assets from lower privileges and apply strong Zero Trust policies. Privileged users and groups without existing restricted management by assignment to Administrative Unit (AU), role-assignable group or Entra ID role will be automatically covered by assignmend to a RMAU (named "UnprotectedAssets").
 
 Currently the following RBAC systems are supported:
 - 🔑 Microsoft Entra roles
@@ -214,14 +215,14 @@ Follow the instructions from [Microsoft Learn](https://learn.microsoft.com/en-us
    * Review the settings in the section `AutomatedEntraOpsUpdate` to configure an automated update of the EntraOps PowerShell module on demand or scheduled basis.
    * Enable and update the following parameters if you want to ingest classification data to Custom Tables in Microsoft Sentinel/Log Analytics Workspace (`IngestToLogAnalytics`) or Microsoft Sentinel WatchLists (`IngestToWatchLists`). You need to add the required parameters of the workspace and/or data collection endpoints.
      * Optional: Use parameter `WatchListTemplates` to define Microsoft Sentinel WatchList templates which should be updated based on EntraOps data. Use the value `All` to update VIP Users, High Value Assets and Identity Correlation watchlists.
-     * Optional: Use parameter `WatchListWorkloadIdentity` to create and update WatchList Templates for Workload Identities which are required for EntraOps workbooks and enhanced enrichment in combination with EntraOps data. Use the value `All` to create the following watchlists:
+     * Optional: Use parameter `WatchListWorkloadIdentity` to create and update WatchList Templates for Workload Identities which are required for EntraOps workbooks and enhanced enrichment in combination with EntraOps data. Use the value `All` or one of the following values to create the WatchLists for Workload Identities:
         - "ManagedIdentityAssignedResourceId" - List of resources with assigned Managed Identity
         - "WorkloadIdentityAttackPaths" - List of attack paths in Microsoft Defender for Cloud for service principals and managed identities
         - "WorkloadIdentityInfo" - List of service principals with detailed information for Workload Identity
         - "WorkloadIdentityRecommendations" - List of recommendations for Workload Identity in Microsoft Entra ID
    * Enable and configure `AutomatedConditionalAccessTargetGroups` if you like to create Security Groups for Conditional Access Policies automatically. Name of the Administrative Unit and scope can be customized by the properties in this section.
-   * Creation and Management of Administrative Unit based on the selected EntraOps Tiering can be automated by using `AutomatedAdministrativeUnitManagement`. All supported objects (Users and groups) will be added to the Administrative Unit. `RestrictedAuMode` allows to control if a RMAU will be created for RBAC Systems outside of Microsoft Entra which are not using role-assignable group usually.
-   * All privileged users outside of protection by role-assignable group, existing (Restricted) Management Administrative Unit (RMAU) or role-assignable groups will be covered by the setting `AutomatedRmauAssignmentsForUnprotectedObjects`. All users or groups without protection will be added automatically to an RMAU for protection.
+   * Creation and Management of Administrative Unit based on the selected EntraOps Tiering can be automated by using `AutomatedAdministrativeUnitManagement`. All supported objects (users and groups) will be added to the Administrative Unit. `RestrictedAuMode` allows to control if a RMAU will be created for RBAC Systems outside of Microsoft Entra which are not using role-assignable group usually.
+   * All privileged users outside of existing protection by role-assignable group, existing (Restricted) Management Administrative Unit (RMAU) or role-assignable groups can be protected by the setting `AutomatedRmauAssignmentsForUnprotectedObjects`. All users or groups without restricted management will be added automatically to an RMAU for protection.
   
 7. Create an application registration with required permissions (Global Admin role required and User Access Administrator). All necessary permissions on Microsoft Graph API permissions but also Azure RBAC roles for data collection and/or ingestion (if configured in `EntraOps.config`) will be added. Administrative Unit, based on the defined name in the config file (`AdminUnitName`) for Conditional Access Groups will be created to scoped delegation on Group Administrator if `ApplyConditionalAccessTargetGroups` has been enabled.
     ```powershell
@@ -333,6 +334,8 @@ The purpsoed tiered level of a user or workload identity will be visible as attr
 In addition, custom security attributes will be also used to build a correlation between the privileged user and the associated PAW device and regular work account.
 - `associatedSecureAdminWorkstation`
 - `associatedWorkAccount`
+
+Permissions to read the custom security attributes needs to be granted manually to the service principal which will be used by EntraOps.
 
 ## Classification of Identity Governance delegation and roles
 Microsoft Entra Identity Governance allows to [delegate and grant roles](https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-delegate) on catalog-level. There are two methods of classification of those delegations in EntraOps.
@@ -511,6 +514,12 @@ The cmdlet can be executed interactively, and changes must be pushed to your rep
 
 Currently, there is also a workflow named "Update-EntraOps" which can be executed on demand or run on scheduled basis (defined in EntraOps.config) and updates the PowerShell module only.
 There are some restrictions to update workflows by another workflow which makes it hard to update the actions automatically.
+
+## Changelog
+
+Version 0.1
+
+Version 0.2
 
 ## Disclaimer and License
 This tool is provided as-is, with no warranties.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Follow the instructions from [Microsoft Learn](https://learn.microsoft.com/en-us
    * Automated updates for classification templates from AzurePrivilegedIAM repository (`AutomatedClassificationUpdate`) or Control Plane scope (`ApplyAutomatedControlPlaneScopeUpdate`) can also be enabled by parameters. Customization of classification updates or data source to identify Control Plane assets is also available from here.
    * Review the settings in the section `AutomatedEntraOpsUpdate` to configure an automated update of the EntraOps PowerShell module on demand or scheduled basis.
    * Enable and update the following parameters if you want to ingest classification data to Custom Tables in Microsoft Sentinel/Log Analytics Workspace (`IngestToLogAnalytics`) or Microsoft Sentinel WatchLists (`IngestToWatchLists`). You need to add the required parameters of the workspace and/or data collection endpoints.
-   * Optional: Use parameter `AddToWatchListTemplates` to define which Microsoft Sentinel WatchList templates should be updated (VIP Users, High Value Assets or Identity Correlation) and automatically added which entities based on EntraOps data.
+   * Optional: Use parameter `WatchListTemplates` to define which Microsoft Sentinel WatchList templates should be updated (VIP Users, High Value Assets or Identity Correlation) and automatically added which entities based on EntraOps data.
 
 7. Create an application registration with required permissions (Global Admin role required). All necessary permissions on Microsoft Graph API permissions but also Azure RBAC roles for ingestion (if configured in `EntraOps.config`) will be added.
     ```powershell

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ EntraOps is a personal research project to show capabilities for automated manag
 - 👑 Identify privileged assets based on automated and full customizable classification of Enterprise Access “tiering” model.
 Integration to customize Control Plane scope automatically by critical assets in Microsoft Security Exposure Management, high-privileges roles/scope in Microsoft Azure RBAC and privileged objects in Microsoft Entra (by EntraOps).
 
-- 🔬 Ingest classification data with all details to custom table in Microsoft Sentinel/Log Analytics Workspace or WatchLists for hunting and enrichment
+- 🔬 Ingest classification data with all details to custom table in Microsoft Sentinel/Log Analytics Workspace or WatchLists for hunting and enrichment. Including support for Sentinel WatchList templates (High Value Assets, VIP Users and Identity Correlation)
+
+- 🤖 Advanced WatchLists to get insights (relation between managed identities and Azure Resources) and information about security posture of Workload Identities by Microsoft Entra Recommendations and Microsoft Defender for Cloud CSPM.
 
 - 📊 Build reports or queries on your classified privileges to identify "tier breach" on Microsoft's Enterprise Access Model or privilege escalation paths. Workbook template to visualize classification data of role assignments (identified by EntraOps) and objects (by using custom security attributes)
 
-- 🛡️ Automated coverage of privileged assets in Conditional Access and Restricted Management Administrative Units (in development) to protect high-privileged assets from lower privileges and apply strong Zero Trust policies.
+- 🛡️ Automated assignment of privileged assets in Conditional Access Groups and Restricted Management Administrative Units to protect high-privileged assets from lower privileges and apply strong Zero Trust policies.
 
 Currently the following RBAC systems are supported:
 - 🔑 Microsoft Entra roles
@@ -211,9 +213,17 @@ Follow the instructions from [Microsoft Learn](https://learn.microsoft.com/en-us
    * Automated updates for classification templates from AzurePrivilegedIAM repository (`AutomatedClassificationUpdate`) or Control Plane scope (`ApplyAutomatedControlPlaneScopeUpdate`) can also be enabled by parameters. Customization of classification updates or data source to identify Control Plane assets is also available from here.
    * Review the settings in the section `AutomatedEntraOpsUpdate` to configure an automated update of the EntraOps PowerShell module on demand or scheduled basis.
    * Enable and update the following parameters if you want to ingest classification data to Custom Tables in Microsoft Sentinel/Log Analytics Workspace (`IngestToLogAnalytics`) or Microsoft Sentinel WatchLists (`IngestToWatchLists`). You need to add the required parameters of the workspace and/or data collection endpoints.
-   * Optional: Use parameter `WatchListTemplates` to define which Microsoft Sentinel WatchList templates should be updated (VIP Users, High Value Assets or Identity Correlation) and automatically added which entities based on EntraOps data.
-
-7. Create an application registration with required permissions (Global Admin role required). All necessary permissions on Microsoft Graph API permissions but also Azure RBAC roles for ingestion (if configured in `EntraOps.config`) will be added.
+     * Optional: Use parameter `WatchListTemplates` to define Microsoft Sentinel WatchList templates which should be updated based on EntraOps data. Use the value `All` to update VIP Users, High Value Assets and Identity Correlation watchlists.
+     * Optional: Use parameter `WatchListWorkloadIdentity` to create and update WatchList Templates for Workload Identities which are required for EntraOps workbooks and enhanced enrichment in combination with EntraOps data. Use the value `All` to create the following watchlists:
+        - "ManagedIdentityAssignedResourceId" - List of resources with assigned Managed Identity
+        - "WorkloadIdentityAttackPaths" - List of attack paths in Microsoft Defender for Cloud for service principals and managed identities
+        - "WorkloadIdentityInfo" - List of service principals with detailed information for Workload Identity
+        - "WorkloadIdentityRecommendations" - List of recommendations for Workload Identity in Microsoft Entra ID
+   * Enable and configure `AutomatedConditionalAccessTargetGroups` if you like to create Security Groups for Conditional Access Policies automatically. Name of the Administrative Unit and scope can be customized by the properties in this section.
+   * Creation and Management of Administrative Unit based on the selected EntraOps Tiering can be automated by using `AutomatedAdministrativeUnitManagement`. All supported objects (Users and groups) will be added to the Administrative Unit. `RestrictedAuMode` allows to control if a RMAU will be created for RBAC Systems outside of Microsoft Entra which are not using role-assignable group usually.
+   * All privileged users outside of protection by role-assignable group, existing (Restricted) Management Administrative Unit (RMAU) or role-assignable groups will be covered by the setting `AutomatedRmauAssignmentsForUnprotectedObjects`. All users or groups without protection will be added automatically to an RMAU for protection.
+  
+7. Create an application registration with required permissions (Global Admin role required and User Access Administrator). All necessary permissions on Microsoft Graph API permissions but also Azure RBAC roles for data collection and/or ingestion (if configured in `EntraOps.config`) will be added. Administrative Unit, based on the defined name in the config file (`AdminUnitName`) for Conditional Access Groups will be created to scoped delegation on Group Administrator if `ApplyConditionalAccessTargetGroups` has been enabled.
     ```powershell
     New-EntraOpsWorkloadIdentity -AppDisplayName entraops -CreateFederatedCredential -GitHubOrg "<YourGitHubUser/Org>" -GitHubRepo "<YourRepoName (e.g., EntraOps-Contoso)> -FederatedEntityType "Branch" -FederatedEntityName "main"
     ```

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Follow the instructions from [Microsoft Learn](https://learn.microsoft.com/en-us
    * Automated updates for classification templates from AzurePrivilegedIAM repository (`AutomatedClassificationUpdate`) or Control Plane scope (`ApplyAutomatedControlPlaneScopeUpdate`) can also be enabled by parameters. Customization of classification updates or data source to identify Control Plane assets is also available from here.
    * Review the settings in the section `AutomatedEntraOpsUpdate` to configure an automated update of the EntraOps PowerShell module on demand or scheduled basis.
    * Enable and update the following parameters if you want to ingest classification data to Custom Tables in Microsoft Sentinel/Log Analytics Workspace (`IngestToLogAnalytics`) or Microsoft Sentinel WatchLists (`IngestToWatchLists`). You need to add the required parameters of the workspace and/or data collection endpoints.
+   * Optional: Use parameter `AddToWatchListTemplates` to define which Microsoft Sentinel WatchList templates should be updated (VIP Users, High Value Assets or Identity Correlation) and automatically added which entities based on EntraOps data.
 
 7. Create an application registration with required permissions (Global Admin role required). All necessary permissions on Microsoft Graph API permissions but also Azure RBAC roles for ingestion (if configured in `EntraOps.config`) will be added.
     ```powershell


### PR DESCRIPTION
Introduction of capabilities to automate assignment of privileges to Conditional Access Groups and (Restricted Management) Administrative Units but also added WatchLists for Workload IDs.

### Added

- Automated update of Microsoft Sentinel WatchList Templates [#8](https://github.com/Cloud-Architekt/EntraOps/issues/8)
- Automated coverage of privileged assets in CA groups and RMAUs [#15](https://github.com/Cloud-Architekt/EntraOps/issues/15) 
- Advanced WatchLists for Workload Identities [#22](https://github.com/Cloud-Architekt/EntraOps/issues/22) 

### Changed
- Separated cmdlet for get classification for Control Plane scope [#19](https://github.com/Cloud-Architekt/EntraOps/issues/19) 

- Added support for -AsSecureString in Az PowerShell (upcoming breaking change) [#20](https://github.com/Cloud-Architekt/EntraOps/issues/20) 

-  Added support for granting required permissions for automated assignment to CA and Administrative Unit

### Fixed
- Remove Azure from ValidateSet until it's available [#18](https://github.com/Cloud-Architekt/EntraOps/issues/18) 
