### PR TITLE
Clean bootstrap update

### DIFF
--- a/EntraOps/Public/Bootstrap/ConvertTo-Mermaid.ps1
+++ b/EntraOps/Public/Bootstrap/ConvertTo-Mermaid.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Converts the PowerShell Object to a Mermaid diagram
+
+.DESCRIPTION
+    Produces a Mermaid digagram of the resources and relationships within the report object.
+
+.PARAMETER ReportObject
+    An object produced by Get-EntraOpsReport
+#>
+function ConvertTo-Mermaid {
+    [OutputType([string])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [pscustomobject]$ReportObject
+    )
+
+    begin {
+        $string = @"
+graph
+
+"@
+        $logPrefix = "[$($MyInvocation.MyCommand)]"
+    }
+
+    process {
+        foreach($catalog in $ReportObject.Catalogs){
+            $string += "  subgraph $($catalog.Catalog.Id) [$($catalog.Catalog.DisplayName)]`n"
+            $string += "`n"
+            
+            $string += "    subgraph $($catalog.Catalog.Id)Roles [Roles]`n"
+            foreach($catalogRole in $catalog.CatalogRoles){
+                $string += "      $($catalogRole.Id)($($catalogRole.RoleDefinition.DisplayName) - $($catalogRole.Principal.AdditionalProperties["displayName"]))`n"
+            }
+            $string += "    end`n"
+
+            $string += "`n"
+            $string += "    subgraph $($catalog.Catalog.Id)Resources [Resources]`n"
+            foreach($catalogResource in $catalog.CatalogResources.Resource|Sort-Object Id -Unique){
+                $string += "      $($catalogResource.Id)($($catalogResource.DisplayName))`n"
+            }
+            $string += "    end`n"
+
+            $string += "`n"
+            $string += "    subgraph $($catalog.Catalog.Id)AccessPackages [Access Packages]`n"
+            foreach($accessPackage in $catalog.AccessPackages){
+                $string += "      subgraph $($accessPackage.AccessPackage.Id) [$($accessPackage.AccessPackage.DisplayName)]`n"
+                    foreach($policy in $accessPackage.Policies){
+                        $string += "        $($policy.Id)($($policy.DisplayName))`n"
+                    }
+                $string += "      end`n"
+            }
+            $string += "    end`n"
+
+            $string += "  end`n`n"
+        }
+
+        foreach($target in $ReportObject.Catalogs.AccessPackages.Assignments.Target|Sort-Object Id -Unique){
+            $string += "$($target.Id)($($target.DisplayName))`n"
+        }
+        $string += "`n"
+
+        foreach($assignment in $ReportObject.Catalogs.AccessPackages.Assignments|Sort-Object Id -Unique){
+            $string += "$($assignment.Target.Id) --> $($assignment.AssignmentPolicy.Id)`n"
+        }
+        $string += "`n"
+
+        $ReportObject.Catalogs.AccessPackages | `
+            Where-Object { $_.Policies.AllowedTargetScope -eq "specificDirectoryUsers" } | `
+            ForEach-Object {
+                $scopePolicy = $_.Policies
+                $scopeResource = $ReportObject.Catalogs.CatalogResources.Resource | `
+                    Where-Object { $_.OriginId -eq $scopePolicy.SpecificAllowedTargets.AdditionalProperties["groupId"] } | `
+                    Sort-Object Id -Unique
+                
+                $string += "$($scopeResource.Id) --> $($scopePolicy.Id)`n"
+
+                <#
+                $_.Policies.SpecificAllowedTargets.AdditionalProperties["groupId"] lookup in
+                  $ReportObject.Catalogs.CatalogResources.Resource.OriginId for 
+                  $entraOps.Catalogs.CatalogResources.Resource.Id --> 
+                  $entraOps.Catalogs.AccessPackages.Policies.Id
+                #>
+            }
+        $string += "`n"
+
+        foreach($accessPackageResources in $ReportObject.Catalogs.AccessPackages){
+            foreach($resource in $accessPackageResources.Resources){
+                $string += "$($accessPackageResources.AccessPackage.Id) --> $($resource.resource.Id)`n"
+            }
+        }
+        $string += "`n"
+
+        foreach($catalogRoleResource in $ReportObject.Catalogs.CatalogRoles){
+            $roleResource = $ReportObject.Catalogs.CatalogResources.Resource | `
+                Where-Object { $_.OriginId -eq $catalogRoleResource.Principal.Id} | `
+                Sort-Object Id -Unique
+            $string += "$($roleResource.Id) --> $($catalogRoleResource.Id)`n"
+        }
+        $string += "`n"
+
+        return $string
+    }
+}

--- a/EntraOps/Public/Bootstrap/Get-EntraOpsReport.ps1
+++ b/EntraOps/Public/Bootstrap/Get-EntraOpsReport.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    Obtain the Entitlement Management resources in a tenant
+
+.DESCRIPTION
+    Creates a reporting object that defines the objects and relationships.
+
+#>
+function Get-EntraOpsReport {
+    [OutputType([psobject])]
+    [cmdletbinding()]
+    param()
+
+    begin {
+        $logPrefix = "[$($MyInvocation.MyCommand)]"
+
+        $entraOps = @()        
+    }
+
+    process {
+        $catalogsOptions = @{
+            ExpandProperty = @("AccessPackages","Resources")
+        }
+        Write-Verbose "$logPrefix Obtaining Catalogs"
+        $catalogs = @(Get-MgEntitlementManagementCatalog @catalogsOptions)
+        $entraOpsCatalogs = @()
+        foreach($catalog in $catalogs){
+            Write-Verbose "$logPrefix Processing Catalog $($catalog.DisplayName)"
+            $catalogRolesSplat = @{
+                ExpandProperty = @("Principal","RoleDefinition")
+                Filter         = "AppScopeId eq '/AccessPackageCatalog/$($catalog.Id)'"
+            }
+            Write-Verbose "$logPrefix Obtaining Catalog Role Assignments"
+            $catalogRoles = @(Get-MgRoleManagementEntitlementManagementRoleAssignment @catalogRolesSplat)
+
+            $catalogResources = @()
+            foreach($catalogResource in $catalog.Resources){
+                Write-Verbose "$logPrefix Processing Catalog Resource $($catalogResource.DisplayName)"
+                $roleSplat = @{
+                    AccessPackageCatalogId  = $($catalog.Id)
+                    Filter                  = "originSystem eq '$($catalogResource.OriginSystem)' and resource/id eq '$($catalogResource.id)'"
+                }
+                Write-Verbose "$logPrefix Obtaining Catalog Resource"
+                $catalogResources += @(Get-MgEntitlementManagementCatalogResourceRole @roleSplat -ExpandProperty Resource)
+            }
+
+            $accessPackagesOptions = @{
+                ExpandProperty = @("resourceRoleScopes(`$expand=role,scope)","Catalog","AssignmentPolicies")
+                Filter         = "Catalog/Id eq '$($catalog.Id)'"
+            }
+            Write-Verbose "$logPrefix Obtaining Access Packages"
+            $accessPackages = @(Get-MgEntitlementManagementAccessPackage @accessPackagesOptions)
+            $entraOpsAccessPackages = @()
+            foreach($accessPackage in $accessPackages){
+                Write-Verbose "$logPrefix Processing Access Package $($accessPackage.DisplayName)"
+                $policies = $accessPackage.AssignmentPolicies
+
+                $assignmentsSplat = @{
+                    ExpandProperty = "AccessPackage(`$expand=Catalog),AccessPackage,Target,AssignmentPolicy"
+                    Filter         = "AccessPackage/Catalog/Id eq '$($catalog.Id)' and State eq 'delivered'"
+                }
+                Write-Verbose "$logPrefix Obtaining Access Package Assignments"
+                $assignments = @(Get-MgEntitlementManagementAssignment @assignmentsSplat)
+
+                $entraOpsAccessPackageResources = @()
+                foreach($resource in $accessPackage.ResourceRoleScopes.Role){
+                    Write-Verbose "$logPrefix Processing Access Package Resource $($resource.OriginId)"
+                    $entraOpsAccessPackageResources += $catalogResources | `
+                        Where-Object {$_.OriginId -eq $resource.OriginId}
+                }
+
+                $entraOpsAccessPackages += [pscustomobject]@{
+                    AccessPackage = $accessPackage
+                    Policies      = $policies
+                    Assignments   = $assignments
+                    Resources     = $entraOpsAccessPackageResources
+                }
+            }
+
+            $entraOpsCatalogs += [pscustomobject]@{
+                Catalog          = $catalog
+                CatalogRoles     = $catalogRoles
+                CatalogResources = $catalogResources
+                AccessPackages   = $entraOpsAccessPackages
+            }
+        }
+
+        $entraOps += [pscustomobject]@{
+            TenantId     = (Get-MgContext).TenantId
+            InvokingUser = (Get-MgContext).Account
+            Catalogs     = $entraOpsCatalogs
+        }
+
+        return $entraOps
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Creates an Azure Resource Group and assigns authorizations
+
+.DESCRIPTION
+    Creates an Azure Resource Group for the specific service, and provides
+    mapping of authorizations for the groups
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+
+.PARAMETER Location
+    Set this to the preferred Azure Region for the Resource Group
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceAZContainer -ServiceName "EntraOps" -ServiceGroups $groups
+
+#>
+function New-EntraOpsServiceAZContainer {
+    [OutputType([psobject])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceName,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [string]$Location = "eastus",
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        try{
+            Write-Verbose "$logPrefix Looking up Azure Resource Group"
+            $resourceGroup = Get-AzResourceGroup -Name "RG-$serviceName" -ErrorAction Stop
+        }catch{
+            if($_.Exception.Message -like "*not exist."){
+                Write-Verbose "$logPrefix Azure Resource Group not found, creating"
+                $resourceGroup = New-AzResourceGroup -Name "RG-$serviceName" -Location $Location
+                $confirmed = $false
+                $i = 0
+                while(-not $confirmed){
+                    Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+                    $checkResourceGroup = Get-AzResourceGroup -Name "RG-$serviceName"
+                    if(($checkResourceGroup|Measure-Object).Count -eq 1){
+                        Write-Verbose "$logPrefix Azure consistency found confirming"
+                        $confirmed = $true
+                        continue
+                    }
+                    $i++
+                    if($i -gt 5){
+                        throw "Resource Group consistency with Azure not achieved"
+                    }
+                    Write-Verbose "$logPrefix Azure resources not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+                }
+            }else{
+                Write-Verbose "$logPrefix Failed to lookup Azure Resource Group"
+                Write-Error $_
+            }
+        }
+        try{
+            $owner = Get-AzRoleDefinition -Name Owner
+            $reader = Get-AzRoleDefinition -Name Reader
+        }catch{
+            Write-Verbose "$logPrefix Failed to fine role definitions"
+            Write-Error $_
+        }
+        $pimAdmins = $ServiceGroups|Where-Object{$_.DisplayName -like "*-PIM-*"}
+        $members = $ServiceGroups|Where-Object{$_.DisplayName -like "*-Members-*"}
+        $rbacSet = @()
+    }
+
+    process {
+        $rbacSet = @()
+        try{
+            Write-Verbose "$logPrefix Looking up Role Assignments for ID: $($resourceGroup.ResourceId)"
+            $rbacSet += Get-AzRoleAssignment -Scope $resourceGroup.ResourceId
+        }catch{
+            Write-Verbose "$logPrefix Failed to get Role Assignments"
+            Write-Error $_
+        }
+        $rbacSplat = @{
+            ResourceGroupName = $resourceGroup.ResourceGroupName
+        }
+        if("$($pimAdmins.Id)_$($owner.Id)" -notin ($rbacSet|ForEach-Object{"$($_.ObjectId)_$($_.RoleDefinitionId)"})){
+            $rbacSplat.RoleDefinitionName = $owner.Name
+            $rbacSplat.ObjectId = $pimAdmins.Id
+            try{
+                Write-Verbose "$logPrefix Creating Role Assignment for ID: $($pimAdmins.Id)"
+                Write-Verbose "$logPrefix $($rbacSplat|ConvertTo-Json -Compress)"
+                $rbacSet += New-AzRoleAssignment @rbacSplat
+            }catch{
+                Write-Verbose "$logPrefix Failed to create role assignment"
+                Write-Error $_
+            }
+        }
+        if("$($members.Id)_$($reader.Id)" -notin ($rbacSet|ForEach-Object{"$($_.ObjectId)_$($_.RoleDefinitionId)"})){
+            $rbacSplat.RoleDefinitionName = $reader.Name
+            $rbacSplat.ObjectId = $members.Id
+            try{
+                Write-Verbose "$logPrefix Creating Role Assignment for ID: $($members.Id)"
+                Write-Verbose "$logPrefix $($rbacSplat|ConvertTo-Json -Compress)"
+                $rbacSet += New-AzRoleAssignment @rbacSplat
+            }catch{
+                Write-Verbose "$logPrefix Failed to create role assignment"
+                Write-Error $_
+            }
+        }
+    }
+
+    end {
+        return [psobject]$resourceGroup
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
@@ -189,7 +189,7 @@ function New-EntraOpsServiceAZContainer {
                     $roleManagementPolicySplat = @{
                         Scope = $resourceGroup.ResourceId
                         Name = $add.RoleId
-                        Rules = @{
+                        Rule = @{
                             id = "Expiration_Admin_Eligibility"
                             IsExpirationRequired = $false
                             ruleType = "RoleManagementPolicyExpirationRule"

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
@@ -32,6 +32,11 @@ function New-EntraOpsServiceAZContainer {
         [Parameter(Mandatory)]
         [psobject[]]$ServiceGroups,
 
+        [ValidateSet("Azure","PIM","Both")]
+        [string]$rbacModel = "PIM",
+
+        [switch]$pimForGroups,
+
         [string]$Location = "eastus",
 
         [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
@@ -67,51 +72,114 @@ function New-EntraOpsServiceAZContainer {
             }
         }
         try{
-            $owner = Get-AzRoleDefinition -Name Owner
-            $reader = Get-AzRoleDefinition -Name Reader
+            $owner           = Get-AzRoleDefinition -Name Owner
+            $reader          = Get-AzRoleDefinition -Name Reader
+            $userAccessAdmin = Get-AzRoleDefinition -Name "User Access Administrator"
+            $contributor     = Get-AzRoleDefinition -Name Contributor
         }catch{
-            Write-Verbose "$logPrefix Failed to fine role definitions"
+            Write-Verbose "$logPrefix Failed to find role definitions"
             Write-Error $_
         }
-        $pimAdmins = $ServiceGroups|Where-Object{$_.DisplayName -like "*-PIM-*"}
-        $members = $ServiceGroups|Where-Object{$_.DisplayName -like "*-Members-*"}
+        $pimAdmins  = $ServiceGroups|Where-Object{$_.DisplayName -like "*-PIM-*"}
+        $members    = $ServiceGroups|Where-Object{$_.DisplayName -like "*-Members-Management"}
+        $control    = $ServiceGroups|Where-Object{$_.DisplayName -like "*-Admins-Control"}
+        $management = $ServiceGroups|Where-Object{$_.DisplayName -like "*-Admins-Management"}
+        $scheduleRequestParams = @{
+            Name = ""
+            RoleDefinitionId = ""
+            PrincipalId = ""
+            Scope = $resourceGroup.ResourceId
+            RequestType = "AdminAssign"
+            Justification = "Initial Bootstrap"
+            ExpirationDuration = "P1Y"
+            ExpirationType = "AfterDuration"
+            ScheduleInfoStartDateTime = (Get-Date -Format o)
+        }
+        $roleDefinitionPrefix = "/Subscriptions/$((Get-AzContext).Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions/"
         $rbacSet = @()
+        $eligibleRbacSet = @()
+        $toAdd = @()
     }
 
     process {
-        $rbacSet = @()
-        try{
-            Write-Verbose "$logPrefix Looking up Role Assignments for ID: $($resourceGroup.ResourceId)"
-            $rbacSet += Get-AzRoleAssignment -Scope $resourceGroup.ResourceId
-        }catch{
-            Write-Verbose "$logPrefix Failed to get Role Assignments"
-            Write-Error $_
-        }
-        $rbacSplat = @{
-            ResourceGroupName = $resourceGroup.ResourceGroupName
-        }
-        if("$($pimAdmins.Id)_$($owner.Id)" -notin ($rbacSet|ForEach-Object{"$($_.ObjectId)_$($_.RoleDefinitionId)"})){
-            $rbacSplat.RoleDefinitionName = $owner.Name
-            $rbacSplat.ObjectId = $pimAdmins.Id
+        if($rbacModel -in ("Azure","Both")){
+            $rbacSet = @()
             try{
-                Write-Verbose "$logPrefix Creating Role Assignment for ID: $($pimAdmins.Id)"
-                Write-Verbose "$logPrefix $($rbacSplat|ConvertTo-Json -Compress)"
-                $rbacSet += New-AzRoleAssignment @rbacSplat
+                Write-Verbose "$logPrefix Looking up Role Assignments for ID: $($resourceGroup.ResourceId)"
+                $rbacSet += Get-AzRoleAssignment -Scope $resourceGroup.ResourceId
             }catch{
-                Write-Verbose "$logPrefix Failed to create role assignment"
+                Write-Verbose "$logPrefix Failed to get Role Assignments"
                 Write-Error $_
             }
+            $rbacSplat = @{
+                ResourceGroupName = $resourceGroup.ResourceGroupName
+            }
+            if($pimForGroups -and "$($pimAdmins.Id)_$($owner.Id)" -notin ($rbacSet|ForEach-Object{"$($_.ObjectId)_$($_.RoleDefinitionId)"})){
+                $rbacSplat.RoleDefinitionName = $owner.Name
+                $rbacSplat.ObjectId = $pimAdmins.Id
+                try{
+                    Write-Verbose "$logPrefix Creating Role Assignment for ID: $($pimAdmins.Id)"
+                    Write-Verbose "$logPrefix $($rbacSplat|ConvertTo-Json -Compress)"
+                    $rbacSet += New-AzRoleAssignment @rbacSplat
+                }catch{
+                    Write-Verbose "$logPrefix Failed to create role assignment"
+                    Write-Error $_
+                }
+            }
+            if("$($members.Id)_$($reader.Id)" -notin ($rbacSet|ForEach-Object{"$($_.ObjectId)_$($_.RoleDefinitionId)"})){
+                $rbacSplat.RoleDefinitionName = $reader.Name
+                $rbacSplat.ObjectId = $members.Id
+                try{
+                    Write-Verbose "$logPrefix Creating Role Assignment for ID: $($members.Id)"
+                    Write-Verbose "$logPrefix $($rbacSplat|ConvertTo-Json -Compress)"
+                    $rbacSet += New-AzRoleAssignment @rbacSplat
+                }catch{
+                    Write-Verbose "$logPrefix Failed to create role assignment"
+                    Write-Error $_
+                }
+            }
         }
-        if("$($members.Id)_$($reader.Id)" -notin ($rbacSet|ForEach-Object{"$($_.ObjectId)_$($_.RoleDefinitionId)"})){
-            $rbacSplat.RoleDefinitionName = $reader.Name
-            $rbacSplat.ObjectId = $members.Id
+
+        if($rbacModel -in ("PIM","Both")){
             try{
-                Write-Verbose "$logPrefix Creating Role Assignment for ID: $($members.Id)"
-                Write-Verbose "$logPrefix $($rbacSplat|ConvertTo-Json -Compress)"
-                $rbacSet += New-AzRoleAssignment @rbacSplat
+                Write-Verbose "$logPrefix Getting PIM Eligible Assignments"
+                $existing = Get-AzRoleEligibilitySchedule -Scope $resourceGroup.ResourceId
+                $eligibleRbacSet += $existing|Select-Object @{n="c";e={$_.RoleDefinitionDisplayName + "_" + $_.PrincipalId}}|ForEach-Object c
             }catch{
-                Write-Verbose "$logPrefix Failed to create role assignment"
+                Write-Verbose "$logPrefix Failed to get PIM Eligible Assignments"
                 Write-Error $_
+            }
+
+            if("$($reader.Name)_$($members.Id)" -notin $eligibleRbacSet){
+                $toAdd += @{
+                    RoleDefinitionId = "$roleDefinitionPrefix/$($reader.Id)"
+                    PrincipalId = $members.Id
+                }
+            }
+            if("$($contributor.Name)_$($management.Id)" -notin $eligibleRbacSet){
+                $toAdd += @{
+                    RoleDefinitionId = "$roleDefinitionPrefix/$($contributor.Id)"
+                    PrincipalId = $management.Id
+                }
+            }
+            if("$($userAccessAdmin.Name)_$($control.Id)" -notin $eligibleRbacSet){
+                $toAdd += @{
+                    RoleDefinitionId = "$roleDefinitionPrefix/$($userAccessAdmin.Id)"
+                    PrincipalId = $control.Id
+                }
+            }
+            
+            foreach($add in $toAdd){
+                try{
+                    Write-Verbose "$logPrefix Creating PIM Eligible Assignment for PrincipalId: $($add.PrincipalId)"
+                    $scheduleRequestParams.Name = [guid]::NewGuid()
+                    $scheduleRequestParams.RoleDefinitionId = $add.RoleDefinitionId
+                    $scheduleRequestParams.PrincipalId = $add.PrincipalId
+                    $rbacSet += New-AzRoleEligibilityScheduleRequest @scheduleRequestParams
+                }catch{
+                    Write-Verbose "$logPrefix Failed to create PIM Eligible Assignment"
+                    Write-Error $_
+                }
             }
         }
     }

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceAZContainer.ps1
@@ -91,8 +91,8 @@ function New-EntraOpsServiceAZContainer {
             Scope = $resourceGroup.ResourceId
             RequestType = "AdminAssign"
             Justification = "Initial Bootstrap"
-            ExpirationDuration = "P1Y"
-            ExpirationType = "AfterDuration"
+            #ExpirationDuration = "P1Y"
+            ExpirationType = "NoExpiration" #AfterDuration
             ScheduleInfoStartDateTime = (Get-Date -Format o)
         }
         $roleDefinitionPrefix = "/Subscriptions/$((Get-AzContext).Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions/"
@@ -153,28 +153,58 @@ function New-EntraOpsServiceAZContainer {
             if("$($reader.Name)_$($members.Id)" -notin $eligibleRbacSet){
                 $toAdd += @{
                     RoleDefinitionId = "$roleDefinitionPrefix/$($reader.Id)"
+                    RoleId = $reader.Id
                     PrincipalId = $members.Id
                 }
             }
             if("$($contributor.Name)_$($management.Id)" -notin $eligibleRbacSet){
                 $toAdd += @{
                     RoleDefinitionId = "$roleDefinitionPrefix/$($contributor.Id)"
+                    RoleId = $contributor.Id
                     PrincipalId = $management.Id
                 }
             }
             if("$($userAccessAdmin.Name)_$($control.Id)" -notin $eligibleRbacSet){
                 $toAdd += @{
                     RoleDefinitionId = "$roleDefinitionPrefix/$($userAccessAdmin.Id)"
+                    RoleId = $userAccessAdmin.Id
                     PrincipalId = $control.Id
                 }
             }
             
             foreach($add in $toAdd){
+                $scheduleRequestParams.Name = [guid]::NewGuid()
+                $scheduleRequestParams.RoleDefinitionId = $add.RoleDefinitionId
+                $scheduleRequestParams.PrincipalId = $add.PrincipalId
+
+                try{
+                    Write-Verbose "$logPrefix Getting role management policy for: $($add.RoleId)"
+                    $policy = Get-AzRoleManagementPolicy -Scope $scheduleRequestParams.Scope -Name $add.RoleId
+                }catch{
+                    Write-Verbose "$logPrefix Failed to get role management policy"
+                    Write-Error $_
+                }
+                if(($policy.Rule|Where-Object{$_.Id -eq "Expiration_Admin_Eligibility"}).IsExpirationRequired){
+                    Write-Verbose "$logPrefix Policy requires eligible expiration, updating"
+                    $roleManagementPolicySplat = @{
+                        Scope = $resourceGroup.ResourceId
+                        Name = $add.RoleId
+                        Rules = @{
+                            id = "Expiration_Admin_Eligibility"
+                            IsExpirationRequired = $false
+                            ruleType = "RoleManagementPolicyExpirationRule"
+                        }
+                    }
+                    try{
+                        Update-AzRoleManagementPolicy @roleManagementPolicySplat
+                    }catch{
+                        Write-Verbose "$logPrefix Failed to update role management policy rules"
+                        Write-Error $_
+                    }
+                }
+
                 try{
                     Write-Verbose "$logPrefix Creating PIM Eligible Assignment for PrincipalId: $($add.PrincipalId)"
-                    $scheduleRequestParams.Name = [guid]::NewGuid()
-                    $scheduleRequestParams.RoleDefinitionId = $add.RoleDefinitionId
-                    $scheduleRequestParams.PrincipalId = $add.PrincipalId
                     $rbacSet += New-AzRoleEligibilityScheduleRequest @scheduleRequestParams
                 }catch{
                     Write-Verbose "$logPrefix Failed to create PIM Eligible Assignment"

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceBootstrap.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceBootstrap.ps1
@@ -1,0 +1,293 @@
+<#
+.SYNOPSIS
+    Creates the necessary authorization structure for a new service
+
+.DESCRIPTION
+    Creates the foundation for handling authorization of a new service
+    in alignment with the Microsoft Enterprise Access Model.
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER ServiceMembers
+    The UserId (i.e., UPN) of the Service members
+    Will default to the identity logged on to Graph
+
+.PARAMETER ServiceOwner
+    The UserId (i.e., UPN) of the Service owner
+    Will default to the identity logged on to Graph
+
+.PARAMETER OwnerIsNotMember
+    Set this flag to not include the Service owner as a member of the service
+
+.PARAMETER ProhibitDirectElevation
+    Set this flag to skip configuration of Entra Priviliged Identity Management
+
+.PARAMETER SkipAzureResourceGroup
+    Set this flag to skip configuration of Azure Resource Group
+
+.PARAMETER AzureRegion
+    Set this to the preferred Azure Region for the Resource Group
+
+.PARAMETER ServiceRoles
+    Define the functional roles of the Service as an object with the columns
+    name,type,groupType. Where name is the functional purpose (e.g., Admins), 
+    type is the EAM classification (e.g., Workload) (an unset value is the 
+    default group), and groupType is the Entra group type (e.g., Unified) (an 
+    unset value will default to a security group). The default value will 
+    create one unified members group, one security management group, one security
+    user workload group, three security admin groups for workload, entitlement,
+    and management.
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceBootstrap
+
+#>
+function New-EntraOpsServiceBootstrap {
+    [OutputType([System.String])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceName,
+
+        [string[]]$ServiceMembers,
+
+        [string]$ServiceOwner,
+
+        [switch]$OwnerIsNotMember,  
+
+        [switch]$ProhibitDirectElevation,
+
+        [switch]$SkipAzureResourceGroup,
+
+        [string]$AzureRegion = "eastus",
+
+        [psobject[]]$ServiceRoles,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        <#
+        $graphModules = "Users,Authentication,Groups,Identity.Governance,Identity.SignIns,Identity.Governance".Split(",")
+        $graphModules|%{Install-Module "Microsoft.Graph.$_"}
+        $azModules = "Accounts,Resources".Split(",")
+        $azModules|%{Install-Module "Az.$_"}
+        #Connect-MgGraph -UseDeviceCode -Scopes Directory.AccessAsUser.All, EntitlementManagement.ReadWrite.All, RoleManagementPolicy.ReadWrite.AzureADGroup, RoleManagementPolicy.ReadWrite.Directory, RoleManagement.ReadWrite.Directory, PrivilegedEligibilitySchedule.ReadWrite.AzureADGroup, PrivilegedAccess.ReadWrite.AzureADGroup
+        #Connect-AzAccount -UseDeviceAuthentication
+        #>
+
+        #todo update all variables to just use this hashtable
+        $report = @{}
+
+        #todo move regions to cmdlets
+        #region ServiceOwner
+        try{
+            #$serviceOwner = Get-MgUser -UserId "adelev@M365x15606866.onmicrosoft.com"
+            Write-Verbose "$logPrefix Service Owner Graph API Lookup"
+            if(-not $PSBoundParameters.ContainsKey("ServiceOwner")){
+                Write-Verbose "$logPrefix ServiceOwner not specified, looking up $((Get-MgContext).Account)"
+                $graphOwner = Get-MgUser -UserId (Get-MgContext).Account
+            }else{
+                Write-Verbose "$logPrefix ServiceOwner set, looking up $ServiceOwner"
+                $graphOwner = Get-MgUser -UserId $ServiceOwner
+            }
+            $owner = "https://graph.microsoft.com/v1.0/users/$($graphOwner.Id)"
+            Write-Verbose "$logPrefix Setting owner as $owner"
+        }catch{
+            Write-Verbose "$logPrefix Failed to process Service Owner"
+            Write-Error $_
+        }
+        #endregion
+
+        #region ServiceMembers
+        try{
+            Write-Verbose "$logPrefix Service Members Graph API Lookup"
+            $graphMembers = @()
+            if(-not $PSBoundParameters.ContainsKey("ServiceMembers")){
+                $ServiceMembers = @(
+                    $(Get-MgUser -UserId (Get-MgContext).Account)
+                )
+            }else{
+                foreach($serviceMember in $ServiceMembers){
+                    $graphMembers += Get-MgUser -UserId $serviceMember
+                }
+            }
+            if($graphOwner.Id -notin $graphMembers.Id -and -not $OwnerIsNotMember){
+                $graphMembers += $graphOwner
+            }
+        }catch{
+            Write-Verbose "$logPrefix Failed to process Service Members"
+            Write-Error $_
+        }
+        #endregion
+
+        #region ServiceRoles
+        Write-Verbose "$logPrefix Service Roles validation"
+        if(-not $PSBoundParameters.ContainsKey("ServiceRoles")){
+            $ServiceRoles = @"
+name,type,groupType
+Members,,Unified
+Members,Management,
+Users,Workload,
+Admins,Workload,
+Admins,Control,
+Admins,Management,
+"@|ConvertFrom-Csv
+        }else{
+            if(($ServiceRoles|Measure-Object).Count -lt 1){
+                throw "`$ServiceRoles was supplied, but did not have any objects defined"
+            }
+
+            foreach($ServiceRole in $ServiceRoles){
+                if(@("Users","Admins","Members") -inotcontains $ServiceRole.name){
+                    throw "$($ServiceRole.name) is not in accepted values of 'Users', 'Admins', or 'Members'"
+                }
+                if(@("Workload","Control","Management","Catalog","") -inotcontains $ServiceRole.type){
+                    throw "$($ServiceRole.type) is not in accepted values of 'Workload', 'Control', 'Management', or ''"
+                }
+                if(@("Unified","Security","") -inotcontains $ServiceRole.groupType){
+                    throw "$($ServiceRole.groupType) is not in accepted values of 'Unified' or ''"
+                }
+                if($ServiceRole.name -ieq "Users" -and $ServiceRole.type -ine "Workload"){
+                    throw "Users should only be for Workload access"
+                }
+            }
+        }
+        #endregion
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing Roles to Groups"
+        $ServiceEntraGroupOptions = @{
+            ServiceName             = $ServiceName
+            ServiceOwner            = $owner
+            ServiceRoles            = $ServiceRoles
+            ProhibitDirectElevation = $ProhibitDirectElevation
+        }
+        $ServiceGroups = New-EntraOpsServiceEntraGroup @ServiceEntraGroupOptions
+        $report.Groups = $ServiceGroups
+        Write-Verbose "$logPrefix Service Groups IDs: $($report.Groups.Id|ConvertTo-Json -Compress)"
+
+        Write-Verbose "$logPrefix Processing Catalog"
+        $ServiceEMCatalogOptions = @{
+            ServiceName  = $ServiceName
+        }
+        $ServiceEMCatalog = New-EntraOpsServiceEMCatalog @ServiceEMCatalogOptions
+        $report.Catalog = $ServiceEMCatalog
+        Write-Verbose "$logPrefix Service Catalog ID: $($report.Catalog.Id)"
+
+        Write-Verbose "$logPrefix Processing Catalog Resources"
+        $ServiceEMCatalogResourceOptions = @{
+            ServiceGroup     = $ServiceGroups
+            ServiceCatalogId = $ServiceEMCatalog.Id
+        }
+        $ServiceEMCatalogResources = New-EntraOpsServiceEMCatalogResource @ServiceEMCatalogResourceOptions
+        $report.CatalogResources = $ServiceEMCatalogResources
+        Write-Verbose "$logPrefix Service Catalog Resource IDs: $($report.CatalogResources.Id|ConvertTo-Json -Compress)"
+
+        Write-Verbose "$logPrefix Processing Catalog Role Assignments"
+        $ServiceEMCatalogResourceRolesOptions = @{
+            ServiceCatalogId = $ServiceEMCatalog.Id
+            ServiceGroups    = $ServiceGroups
+        }
+        $ServiceEMCatalogResourceRoles = New-EntraOpsServiceEMCatalogResourceRole @ServiceEMCatalogResourceRolesOptions
+        $report.CatalogResourceRoles = $ServiceEMCatalogResourceRoles
+        Write-Verbose "$logPrefix Service Catalog Resource Role IDs: $($report.CatalogResourceRoles.Id|ConvertTo-Json -Compress)"
+
+        Write-Verbose "$logPrefix Processing Access Packages"
+        $ServiceEMAccessPackagesOptions = @{
+            ServiceName      = $ServiceName
+            ServiceCatalogId = $ServiceEMCatalog.Id
+            ServiceRoles     = $ServiceRoles
+        }
+        $ServiceEMAccessPackages = New-EntraOpsServiceEMAccessPackage @ServiceEMAccessPackagesOptions
+        $report.AccessPackages = $ServiceEMAccessPackages
+        Write-Verbose "$logPrefix Service Access Package IDs: $($report.AccessPackages.Id|ConvertTo-Json -Compress)"
+
+        Write-Verbose "$logPrefix Processing assignment of Entra Groups to Access Packages"
+        $ServiceEMAccessPackageResourceAssignmentOptions = @{
+            ServicePackages         = $ServiceEMAccessPackages
+            ServiceGroups           = $ServiceGroups
+            ServiceCatalogResources = $ServiceEMCatalogResources
+            ServiceCatalogId        = $ServiceEMCatalog.Id
+        }
+        $ServiceEMAccessPackageAssignments = New-EntraOpsServiceEMAccessPackageResourceAssignment @ServiceEMAccessPackageResourceAssignmentOptions
+        $report.AccessPackageAssignments = $ServiceEMAccessPackageAssignments
+        Write-Verbose "$logPrefix Service Access Package Assignment IDs: $($report.AccessPackageAssignments.Id|ConvertTo-Json -Compress)"
+
+        Write-Verbose "$logPrefix Processing access package policy assignment"
+        $ServiceEMAssignmentPolicyOptions = @{
+            ServiceCatalogId = $ServiceEMCatalog.Id
+            ServicePackages  = $ServiceEMAccessPackages
+            ServiceGroups    = $ServiceGroups
+            ServiceName      = $ServiceName
+        }
+        $ServiceEMAssignmentPolicies = New-EntraOpsServiceEMAssignmentPolicy @ServiceEMAssignmentPolicyOptions
+        $report.AssignmentPolicies = $ServiceEMAssignmentPolicies
+        Write-Verbose "$logPrefix Service Access Package Assignment Policy IDs: $($report.AssignmentPolicies.Id|ConvertTo-Json -Compress)"
+
+        Write-Verbose "$logPrefix Processing access package assignments"
+        $ServiceEMAssignmentOptions = @{
+            ServiceCatalogId          = $ServiceEMCatalog.Id
+            ServiceMembers            = $graphMembers
+            ServiceOwner              = $graphOwner
+            ServiceAssignmentPolicies = $ServiceEMAssignmentPolicies
+            ServicePackages           = $ServiceEMAccessPackages
+        }
+        $ServiceEMAssignments = New-EntraOpsServiceEMAssignment @ServiceEMAssignmentOptions
+        $report.Assignments = $ServiceEMAssignments
+        Write-Verbose "$logPrefix Service Access Package Assignment IDs: $($report.ASsignments.Id|ConvertTo-Json -Compress)"
+
+        if(-not $ProhibitDirectElevation){
+            Write-Verbose "$logPrefix Processing PIM policies"
+            $ServicePIMPolicyOptions = @{
+                ServiceGroups = $ServiceGroups
+            }
+            $ServicePIMPolicies = New-EntraOpsServicePIMPolicy @ServicePIMPolicyOptions
+            $report.PimPolicies = $ServicePIMPolicies
+            Write-Verbose "$logPrefix Service PIM Policy IDs: $($report.PimPolicies.Id|ConvertTo-Json -Compress)"
+
+            Write-Verbose "$logPrefix Processing PIM assignments"
+            $ServicePIMAssignmentOptions = @{
+                ServiceGroups = $ServiceGroups
+            }
+            $ServicePIMAssignments = New-EntraOpsServicePIMAssignment @ServicePIMAssignmentOptions
+            $report.PimAssignments = $ServicePIMAssignments
+            Write-Verbose "$logPrefix Service PIM Assignment IDs: $($report.PimAssignments.Id|ConvertTo-Json -Compress)"
+        }
+
+        if(-not $SkipAzureResourceGroup){
+            Write-Verbose "$logPrefix Processing Azure Container"
+            $ServiceAZContainerOptions = @{
+                ServiceName   = $ServiceName
+                ServiceGroups = $ServiceGroups
+                Location      = $AzureRegion
+            }
+            $ServiceAzContainer = New-EntraOpsServiceAZContainer @ServiceAZContainerOptions
+            $report.AzContainer = $ServiceAzContainer
+            Write-Verbose "$logPrefix Service Az Container ID: $($report.AzContainer.ResourceId|ConvertTo-Json -Compress)"
+        }
+
+        return $report
+    }
+}
+
+#Fix Docs
+#Fix Try/Catches
+#Add Bootstrap for LZ
+
+##Extras
+#Created KV
+#KV IAM Role Assignments
+#Created Bastion
+#Created VM
+#Set managed identity
+#Assign managed identity to member management and user workload
+#Reader on Sub
+#Peered Bastion and VM
+#Install pwsh
+#Set-AzKeyVaultSecret -VaultName "kv-Transacation" -Name "key-vm-Transaction" -SecretValue $(ConvertTo-SecureString (gc ./.key.pem -Raw) -AsPlainText -Force)

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAccessPackage.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAccessPackage.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Creates access packages
+
+.DESCRIPTION
+    Creates an access package in the catalog for the roles
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER ServiceCatalogId
+    The Service Catalog GUID
+
+.PARAMETER ServiceRoles
+    The EntraOps Service Roles object
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMAccessPackage -ServiceName "EntraOps" -ServiceCatalogId "<GUID>" -ServiceRoles $roles
+
+#>
+function New-EntraOpsServiceEMAccessPackage {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceName,
+
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogId,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceRoles,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $accessPackageOptions = @{
+            ExpandProperty = @("resourceRoleScopes(`$expand=role,scope)","Catalog")
+            Filter         = "Catalog/Id eq '$($ServiceCatalogId)'"
+        }
+        Write-Verbose "$logPrefix Looking up Access Packages"
+        try{
+            $ServiceAccessPackages = @()
+            $ServiceAccessPackages += Get-MgEntitlementManagementAccessPackage @accessPackageOptions
+        }catch{
+            Write-Verbose "$logPrefix Failed to find Access Packages"
+            Write-Error $_
+        }
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing $(($ServiceRoles|Where-Object{$_.groupType -ne "Unified"}|Measure-Object).Count) Access Package Roles"
+        foreach($role in $ServiceRoles|Where-Object{$_.groupType -ne "Unified"}){
+            $packageParams = @{
+                catalog = @{
+                    id = $ServiceCatalogId
+                }
+                DisplayName = "AP-$ServiceName-$($role.name +"-"+ $role.type)"
+                Description = "Access Package for $ServiceName $($role.type +" "+ $role.name)"
+            }
+            if($packageParams.DisplayName -notin $ServiceAccessPackages.DisplayName){
+                try{
+                    Write-Verbose "$logPrefix Creating Access Package"
+                    $ServiceAccessPackages += New-MgEntitlementManagementAccessPackage -BodyParameter $packageParams
+                }catch{
+                    Write-Verbose "$logPrefix Failed to create Access Package"
+                    Write-Error $_
+                }
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkServiceAccessPackages = @()
+            $checkServiceAccessPackages = Get-MgEntitlementManagementAccessPackage @accessPackageOptions
+            if((Compare-Object $ServiceAccessPackages $checkServiceAccessPackages|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Access Package object consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkServiceAccessPackages
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAccessPackageResourceAssignment.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAccessPackageResourceAssignment.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+    Creates resource assignments in the access packages
+
+.DESCRIPTION
+    Registers the catalog resources with the access packages
+
+.PARAMETER ServiceCatalogId
+    The Service Catalog GUID
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+    
+.PARAMETER ServicePackages
+    The Graph Access Package objects
+
+.PARAMETER ServiceCatalogResources
+    The Graph Catalog Resource objects
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMAccessPackageResourceAssignment -ServiceCatalogId "<GUID>" -ServiceGroups $groups -ServicePackages $packages -ServiceCatalogResources $resources
+
+#>
+function New-EntraOpsServiceEMAccessPackageResourceAssignment {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogId,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServicePackages,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceCatalogResources,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $assignedRoles = @()
+        $assignedRoles += $ServicePackages.ResourceRoleScopes
+        $packageRoles = @()
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing Access Package Assignments for $(($ServiceGroups|Measure-Object).Count) Groups"
+        foreach($group in $ServiceGroups){
+            if($group.DisplayName -like "*-PIM-*"){continue}
+            $resource = $ServiceCatalogResources|Where-Object{`
+                $_.DisplayName -eq $group.DisplayName -and `
+                $_.OriginSystem -eq "AadGroup"
+            }
+            Write-Verbose "$logPrefix Processing Access Package Resource ID: $($resource.Id)"
+            
+            $gn = $group.DisplayName.Substring(2,$group.DisplayName.Length-2)
+            $package = $ServicePackages|Where-Object{`
+                $_.DisplayName.Substring(2,$_.DisplayName.Length-2) -eq $gn
+            }
+            if(-not $package){
+                $package = $ServicePackages|Where-Object{`
+                    $_.DisplayName -like "*Users-Workload"
+                }
+            }
+            Write-Verbose "$logPrefix Processing Access Package ID: $($package.Id)"
+
+            #Get available roles for resource in Catalog
+            #Used to validate if Access Package exists for resource role
+            $roleSplat = @{
+                AccessPackageCatalogId = $ServiceCatalogId
+                Filter = "originSystem eq 'AadGroup' and resource/id eq '$($resource.id)'"
+            }
+            try{
+                Write-Verbose "$logPrefix Getting Catalog Resource Roles for Resource ID: $($resource.id)"
+                $resourceRoles = Get-MgEntitlementManagementCatalogResourceRole @roleSplat -ExpandProperty Resource
+            }catch{
+                Write-Verbose "$logPrefix Failed to get Catalog Resource Roles"
+                Write-Error $_
+            }
+            Write-Verbose "$logPrefix Found Catalog Resource Roles: $($resourceRoles.OriginId|ConvertTo-Json -Compress)"
+
+            $resourceParams = @{
+                role = @{
+                    id = $resource.OriginId
+                    originId = ($resourceRoles|Where-Object{$_.DisplayName -eq "Member"}).OriginId
+                    originSystem =  $resource.OriginSystem
+                    resource = @{
+                        id = $resource.Id
+                        originId = $resource.OriginId
+                        originSystem = $resource.OriginSystem
+                    }
+                }
+                scope = @{
+                    originId = $resource.OriginId
+                    originSystem = $resource.OriginSystem
+                }
+            }
+            $ex = $package.ResourceRoleScopes|ForEach-Object{"$($_.Role.OriginId)_$($_.Scope.OriginId)"}
+            $packageRoles += $ex
+            $tb = "$($resourceParams.role.originId)_$($resourceParams.scope.originId)"
+            if($tb -notin $ex){
+                try{
+                    Write-Verbose "$logPrefix Creating new role assignment"
+                    Write-Verbose "$logPrefix Resource Param: $($resourceParams|ConvertTo-Json -Compress)"
+                    $assignedRoles += New-MgEntitlementManagementAccessPackageResourceRoleScope -AccessPackageId $package.Id -BodyParameter $resourceParams
+                    $packageRoles += $tb
+                }catch{
+                    Write-Verbose "$logPrefix Failed to create new role assignment"
+                    Write-Error $_
+                }
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $accessPackageOptions = @{
+                ExpandProperty = @("resourceRoleScopes(`$expand=role,scope)","Catalog")
+                Filter         = "Catalog/Id eq '$($ServiceCatalogId)'"
+            }
+            $checkServiceAccessPackages = @()
+            $checkServiceAccessPackages = Get-MgEntitlementManagementAccessPackage @accessPackageOptions
+            $checkAssignments = $checkServiceAccessPackages.ResourceRoleScopes|ForEach-Object{"$($_.Role.OriginId)_$($_.Scope.OriginId)"}
+
+            if((Compare-Object $($packageRoles|Sort-Object -Unique) $checkAssignments|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Access Package role assignment consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkServiceAccessPackages
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAssignment.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAssignment.ps1
@@ -103,15 +103,17 @@ function New-EntraOpsServiceEMAssignment {
         }
 
         # Update this to `in` if upstream function ever switches to array
-        try{
-            $assignmentParams.assignment.targetId = $ServiceOwner.Id
-            $assignmentParams.assignment.assignmentPolicyId = ($ServiceAssignmentPolicies|Where-Object{$_.DisplayName -eq "Initial Management Admin Policy"}).Id
-            $assignmentParams.assignment.accessPackageId = ($ServicePackages|Where-Object{$_.DisplayName -like "*Admins-Management"}).Id
-            Write-Verbose "$logPrefix Creating Assignment Request for Service Owner - $($assignmentParams|ConvertTo-Json -Compress)"
-            $assignmentRequests += New-MgEntitlementManagementAssignmentRequest -BodyParameter $assignmentParams
-        }catch{
-            Write-Verbose "$logPrefix Failed to create Assignment Request for Service Owner"
-            Write-Error $_
+        if($ServiceOwner.Id -notin $assignments.Target.ObjectId -and $ServiceOwner.Id -notin $assignmentRequests.Assignment.Target.ObjectId){
+            try{
+                $assignmentParams.assignment.targetId = $ServiceOwner.Id
+                $assignmentParams.assignment.assignmentPolicyId = ($ServiceAssignmentPolicies|Where-Object{$_.DisplayName -eq "Initial Management Admin Policy"}).Id
+                $assignmentParams.assignment.accessPackageId = ($ServicePackages|Where-Object{$_.DisplayName -like "*Admins-Management"}).Id
+                Write-Verbose "$logPrefix Creating Assignment Request for Service Owner - $($assignmentParams|ConvertTo-Json -Compress)"
+                $assignmentRequests += New-MgEntitlementManagementAssignmentRequest -BodyParameter $assignmentParams
+            }catch{
+                Write-Verbose "$logPrefix Failed to create Assignment Request for Service Owner"
+                Write-Error $_
+            }
         }
     }
 
@@ -122,10 +124,11 @@ function New-EntraOpsServiceEMAssignment {
             Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
             $checkAssignments = @()
             $checkAssignments += Get-MgEntitlementManagementAssignment @assignmentsSplat
-            Write-Verbose "$logPrefix Service Member IDs: $($ServiceMembers.Id|ConvertTo-Json -Compress)"
+            $checkIds = $ServiceMembers.Id + $ServiceOwner.Id
+            Write-Verbose "$logPrefix Service Member IDs: $($checkIds|ConvertTo-Json -Compress)"
             Write-Verbose "$logPrefix Assignment Target IDs: $($checkAssignments.Target.ObjectId|ConvertTo-Json -Compress)"
             if(-not ($null -eq $checkAssignments.Target.ObjectId)){
-                if((Compare-Object $ServiceMembers.Id $checkAssignments.Target.ObjectId|Measure-Object).Count -eq 0){
+                if((Compare-Object $checkIds $checkAssignments.Target.ObjectId|Measure-Object).Count -eq 0){
                     Write-Verbose "$logPrefix Graph consistency found confirming"
                     $confirmed = $true
                     continue

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAssignment.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAssignment.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+    Creates access package resource assignments
+
+.DESCRIPTION
+    Assigns catalog resources with access packages
+
+.PARAMETER ServiceCatalogId
+    The Service Catalog GUID
+
+.PARAMETER Service Members
+    The Graph User URIs object
+    
+.PARAMETER ServicePackages
+    The Graph Access Package objects
+
+.PARAMETER ServiceAssignmentPolicies
+    The Graph Assignment Policy objects
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMAssignment -ServiceCatalogId "<GUID>" -ServiceMembers $members -ServicePackages $packages -ServiceAssignmentPolicies $policies
+
+#>
+function New-EntraOpsServiceEMAssignment {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogId,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceMembers,
+
+        [Parameter(Mandatory)]
+        [psobject]$ServiceOwner,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceAssignmentPolicies,
+        
+        [Parameter(Mandatory)]
+        [psobject[]]$ServicePackages,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $assignmentRequests = @()
+        $assignments = @()
+
+        $assignmentRequestsSplat = @{
+            ExpandProperty = "Assignment(`$expand=Target),AccessPackage,Assignment"
+            Filter = "State eq 'submitted'"
+        }
+        try{
+            Write-Verbose "$logPrefix Looking up Assignment Requests"
+            $assignmentRequests += Get-MgEntitlementManagementAssignmentRequest @assignmentRequestsSplat
+        }catch{
+            Write-Verbose "$logPrefix Failed to find Assignment Requests"
+            Write-Error $_
+        }
+
+        $assignmentsSplat = @{
+            ExpandProperty = "AccessPackage(`$expand=Catalog),AccessPackage,Target"
+            Filter = "AccessPackage/Catalog/Id eq '$ServiceCatalogId' and State eq 'delivered'"
+        }
+        Write-Verbose "$logPrefix $($assignmentsSplat|ConvertTo-Json -Compress)"
+        try{
+            $assignments += Get-MgEntitlementManagementAssignment @assignmentsSplat
+            if(($assignments|Measure-Object).Count -gt 0){
+                Write-Verbose "$logPrefix Found Access Package Assignment IDs: $($assignments.Id|ConvertTo-Json -Compress)"
+            }
+        }catch{
+            Write-Verbose "$logPrefix Failed to find Assignments"
+            Write-Error $_
+        }
+
+        $assignmentParams = @{
+            requestType = "adminAdd"
+            assignment = @{
+                targetId = ""
+                assignmentPolicyId = ($ServiceAssignmentPolicies|Where-Object{$_.DisplayName -eq "Initial Workload Membership Policy"}).Id
+                accessPackageId = ($ServicePackages|Where-Object{$_.DisplayName -like "*Members-Workload"}).Id
+            }
+        }
+    }
+
+    process {
+        foreach($member in $ServiceMembers){
+            Write-Verbose "$logPrefix Processing Service Member ID: $($member.Id)"
+            $assignmentParams.assignment.targetId = $member.Id
+            if($member.Id -notin $assignments.Target.ObjectId -and $member.Id -notin $assignmentRequests.Assignment.Target.ObjectId){
+                try{
+                    Write-Verbose "$logPrefix Creating Assignment Request"
+                    $assignmentRequests += New-MgEntitlementManagementAssignmentRequest -BodyParameter $assignmentParams
+                }catch{
+                    Write-Verbose "$logPrefix Failed to create Assignment Request"
+                    Write-Error $_
+                }
+            }
+        }
+
+        # Update this to `in` if upstream function ever switches to array
+        try{
+            $assignmentParams.assignment.targetId = $ServiceOwner.Id
+            $assignmentParams.assignment.assignmentPolicyId = ($ServiceAssignmentPolicies|Where-Object{$_.DisplayName -eq "Initial Management Admin Policy"}).Id
+            $assignmentParams.assignment.accessPackageId = ($ServicePackages|Where-Object{$_.DisplayName -like "*Admins-Management"}).Id
+            Write-Verbose "$logPrefix Creating Assignment Request for Service Owner - $($assignmentParams|ConvertTo-Json -Compress)"
+            $assignmentRequests += New-MgEntitlementManagementAssignmentRequest -BodyParameter $assignmentParams
+        }catch{
+            Write-Verbose "$logPrefix Failed to create Assignment Request for Service Owner"
+            Write-Error $_
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkAssignments = @()
+            $checkAssignments += Get-MgEntitlementManagementAssignment @assignmentsSplat
+            Write-Verbose "$logPrefix Service Member IDs: $($ServiceMembers.Id|ConvertTo-Json -Compress)"
+            Write-Verbose "$logPrefix Assignment Target IDs: $($checkAssignments.Target.ObjectId|ConvertTo-Json -Compress)"
+            if(-not ($null -eq $checkAssignments.Target.ObjectId)){
+                if((Compare-Object $ServiceMembers.Id $checkAssignments.Target.ObjectId|Measure-Object).Count -eq 0){
+                    Write-Verbose "$logPrefix Graph consistency found confirming"
+                    $confirmed = $true
+                    continue
+                }
+            }else{
+                Write-Verbose "$logPrefix No assignments available skipping comparison"
+            }
+            $i++
+            if($i -eq 5){
+                Write-Warning "$logPrefix Fulfillment can take 5+ minutes to complete"
+            }
+            if($i -gt 9){
+                throw "Access Package Assignment consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkAssignments
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAssignmentPolicy.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMAssignmentPolicy.ps1
@@ -1,0 +1,364 @@
+<#
+.SYNOPSIS
+    Creates an Entra Group based on the provided role
+
+.DESCRIPTION
+    Creates an Entra Group relative to the specific role supplied. Unless for
+    custom implementations, should be used by New-EntraOpsServiceBootstrap.
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER ServiceCatalogId
+    The Service Catalog GUID
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+    
+.PARAMETER ServicePackages
+    The Graph Access Package objects
+
+.PARAMETER ServiceCatalogResources
+    The Graph Catalog Resource objects
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMAssignmentPolicy -ServiceName "EntraOps" -ServiceCatalogId "<GUID>" -ServiceGroups $groups -ServicePackages $packages
+
+#>
+function New-EntraOpsServiceEMAssignmentPolicy {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceName,
+
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogId,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServicePackages,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $policies = @()
+        $policiesSplat = @{
+            ExpandProperty = "AccessPackage,Catalog"
+            Filter = "Catalog/Id eq '$ServiceCatalogId'"
+        }
+        try{
+            Write-Verbose "$logPrefix Looking up Assignment Policy"
+            $policies += Get-MgEntitlementManagementAssignmentPolicy @policiesSplat
+        }catch{
+            Write-Error $_
+        }
+        $policyParams = @{
+            requestorSettings = @{
+                enableTargetsToSelfAddAccess = $true
+                enableTargetsToSelfUpdateAccess = $false
+                enableTargetsToSelfRemoveAccess = $true
+                allowCustomAssignmentSchedule = $false
+                enableOnBehalfRequestorsToAddAccess = $false
+                enableOnBehalfRequestorsToUpdateAccess = $false
+                enableOnBehalfRequestorsToRemoveAccess = $false
+            }
+            accessPackage = @{
+                id = ""
+            }
+            reviewSettings = @{
+                isEnabled = $true
+                expirationBehavior = "keepAccess"
+                isRecommendationEnabled = $true
+                isReviewerJustificationRequired = $true
+                isSelfReview = $false
+                schedule = @{
+                    startDateTime = (Get-Date).AddDays(4)
+                    expiration = @{
+                        duration = "P25D"
+                        type = "afterDuration"
+                    }
+                    recurrence = @{
+                        pattern = @{
+                            type = "absoluteMonthly"
+                            interval = 3
+                            month = 0
+                            dayOfMonth = 0
+                        }
+                        range = @{
+                            type = "noEnd"
+                        }
+                    }
+                }
+                primaryReviewers = @(
+                    @{
+                        "@odata.type" = "#microsoft.graph.groupMembers"
+                        groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Catalog"}).Id)
+                    }
+                )
+            }
+        }
+        $baselinePolicyParams = @{
+            displayName = "Baseline Policy"
+            description = "The baseline policy for $ServiceName access packages."
+            allowedTargetScope = "specificDirectoryUsers"
+            specificAllowedTargets = @(
+                @{
+                    "@odata.type" = "#microsoft.graph.groupMembers"
+                    groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Catalog"}).Id)
+                }
+            )
+            expiration = @{
+                duration = "P5D"
+                type = "afterDuration"
+            }
+            requestApprovalSettings = @{
+                isApprovalRequiredForAdd = $true
+                isApprovalRequiredForUpdate = $false
+                stages = @(
+                    @{
+                        durationBeforeAutomaticDenial = "P2D"
+                        isApproverJustificationRequired = $true
+                        isEscalationEnabled = $false
+                        durationBeforeEscalation = "PT0S"
+                        primaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Catalog"}).Id)
+                            }
+                        )
+                    }
+                )
+            }
+        }
+        $initialPolicyParams = @{
+            displayName = "Initial Membership Policy"
+            description = "The initial membership policy for $ServiceName."
+            allowedTargetScope = "allMemberUsers"
+            expiration = @{
+                type = "noExpiration"
+            }
+            requestApprovalSettings = @{
+                isApprovalRequiredForAdd = $true
+                isApprovalRequiredForUpdate = $false
+                stages = @(
+                    @{
+                        durationBeforeAutomaticDenial = "P7D"
+                        isApproverJustificationRequired = $true
+                        isEscalationEnabled = $false
+                        durationBeforeEscalation = "PT0S"
+                        primaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.requestorManager"
+                                managerLevel = 1
+                            }
+                        )
+                        fallbackPrimaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Catalog"}).Id)
+                            }
+                        )
+                    },
+                    @{
+                        durationBeforeAutomaticDenial = "P14D"
+                        isApproverJustificationRequired = $true
+                        isEscalationEnabled = $false
+                        durationBeforeEscalation = "PT0S"
+                        primaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Catalog"}).Id)
+                            }
+                        )
+                    }
+                )
+            }
+        }
+        $managementInitialPolicyParams = @{
+            displayName = "Initial Management Admin Policy"
+            description = "The initial admin policy for $ServiceName."
+            allowedTargetScope = "specificDirectoryUsers"
+            specificAllowedTargets = @(
+                @{
+                    "@odata.type" = "#microsoft.graph.groupMembers"
+                    groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Catalog"}).Id)
+                }
+            )
+            expiration = @{
+                type = "noExpiration"
+            }
+            requestApprovalSettings = @{
+                isApprovalRequiredForAdd = $false
+                isApprovalRequiredForUpdate = $false
+            }
+        }
+        $workloadPlanePolicyParams = @{
+            displayName = "Workload Plane Policy"
+            description = "The Workload Plane Policy for $ServiceName access packages."
+            allowedTargetScope = "specificDirectoryUsers"
+            specificAllowedTargets = @(
+                @{
+                    "@odata.type" = "#microsoft.graph.groupMembers"
+                    groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Workload"}).Id)
+                }
+            )
+            expiration = @{
+                duration = "P5D"
+                type = "afterDuration"
+            }
+            requestApprovalSettings = @{
+                isApprovalRequiredForAdd = $true
+                isApprovalRequiredForUpdate = $false
+                stages = @(
+                    @{
+                        durationBeforeAutomaticDenial = "P2D"
+                        isApproverJustificationRequired = $true
+                        isEscalationEnabled = $false
+                        durationBeforeEscalation = "PT0S"
+                        primaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Admins-Management"}).Id)
+                            }
+                        )
+                    }
+                )
+            }
+        }
+        $managementPlanePolicyParams = @{
+            displayName = "Management Plane Policy"
+            description = "The Management Plane Policy for $ServiceName access packages."
+            allowedTargetScope = "specificDirectoryUsers"
+            specificAllowedTargets = @(
+                @{
+                    "@odata.type" = "#microsoft.graph.groupMembers"
+                    groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Management"}).Id)
+                }
+            )
+            expiration = @{
+                duration = "P5D"
+                type = "afterDuration"
+            }
+            requestApprovalSettings = @{
+                isApprovalRequiredForAdd = $true
+                isApprovalRequiredForUpdate = $false
+                stages = @(
+                    @{
+                        durationBeforeAutomaticDenial = "P2D"
+                        isApproverJustificationRequired = $true
+                        isEscalationEnabled = $false
+                        durationBeforeEscalation = "PT0S"
+                        primaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Admins-Management"}).Id)
+                            }
+                        )
+                        <#
+                        fallbackPrimaryApprovers = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Admins-Control"}).Id)
+                            }
+                        )
+                        #>
+                    }
+                )
+            }
+        }
+    }
+
+    process {
+        foreach($package in $ServicePackages){
+            $policyParams.accessPackage.id = $package.Id
+            if($package.Id -notin $policies.AccessPackage.Id){
+                try{
+                    Write-Verbose "$logPrefix Assigning Policy for Access Package ID: $($package.Id)"
+                    if($package.DisplayName -like "*Members-Workload"){
+                        $params = $policyParams + $initialPolicyParams
+                        $params.displayName = "Initial Workload Membership Policy"
+                        $policies += New-MgEntitlementManagementAssignmentPolicy -BodyParameter $params
+                    }elseif($package.displayName -like "*Members-Management"){
+                        $params = $initialPolicyParams
+                        $params.displayName = "Initial Management Membership Policy"
+                        $params.allowedTargetScope = "specificDirectoryUsers"
+                        $params.specificAllowedTargets = @(
+                            @{
+                                "@odata.type" = "#microsoft.graph.groupMembers"
+                                groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Members-Workload"}).Id)
+                            }
+                        )
+                        $params.requestApprovalSettings.stages = @(
+                            @{
+                                durationBeforeAutomaticDenial = "P2D"
+                                isApproverJustificationRequired = $true
+                                isEscalationEnabled = $false
+                                durationBeforeEscalation = "PT0S"
+                                primaryApprovers = @(
+                                    @{
+                                        "@odata.type" = "#microsoft.graph.groupMembers"
+                                        groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Admins-Management"}).Id)
+                                    }
+                                )
+                                <# Not supported when heirarchical manager is not the primary approver
+                                fallbackPrimaryApprovers = @(
+                                    @{
+                                        "@odata.type" = "#microsoft.graph.groupMembers"
+                                        groupId = $(($ServiceGroups|Where-Object{$_.DisplayName -like "*Admins-Control"}).Id)
+                                    }
+                                )
+                                #>
+                            }
+                        )
+                        $params = $policyParams + $params
+                        $policies += New-MgEntitlementManagementAssignmentPolicy -BodyParameter $params
+                    }elseif($package.displayName -like "*Admins-Workload"){
+                        $params = $policyParams + $workloadPlanePolicyParams
+                        $policies += New-MgEntitlementManagementAssignmentPolicy -BodyParameter $params
+                    }elseif($package.displayName -like "*Admins-Management"){
+                        #Eligible policy assignment
+                        $params = $policyParams + $managementPlanePolicyParams
+                        $policies += New-MgEntitlementManagementAssignmentPolicy -BodyParameter $params
+                        #Active policy assignment
+                        $params = $policyParams + $managementInitialPolicyParams
+                        $policies += New-MgEntitlementManagementAssignmentPolicy -BodyParameter $params
+                    }else{
+                        $params = $policyParams + $baselinePolicyParams
+                        $policies += New-MgEntitlementManagementAssignmentPolicy -BodyParameter $params
+                    }
+                }catch{
+                    Write-Verbose "$logPrefix Failed to Assign Policy"
+                    Write-Error $_
+                }
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkPolicies = @()
+            $checkPolicies = Get-MgEntitlementManagementAssignmentPolicy @policiesSplat
+            if((Compare-Object $policies $checkPolicies|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Access Package object consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkPolicies
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMCatalog.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMCatalog.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+    Creates a catalog
+
+.DESCRIPTION
+    Creates an Entitlement Management Catalog
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMCatalog -ServiceName "EntraOps"
+
+#>
+function New-EntraOpsServiceEMCatalog {
+    [OutputType([psobject])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceName,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        try{
+            Write-Verbose "$logPrefix Looking up Catalog"
+            $catalog = Get-MgEntitlementManagementCatalog -DisplayNameEq "Catalog-$ServiceName" -ExpandProperty AccessPackages,Resources
+        }catch{
+            Write-Verbose "$logPrefix Failed to find Catalog"
+            Write-Error $_
+        }
+    }
+
+    process {
+        try{
+            if(-not $catalog){
+                Write-Verbose "$logPrefix Creating Catalog"
+                $catalog = New-MgEntitlementManagementCatalog -DisplayName "Catalog-$ServiceName"
+            }
+        }catch{
+            Write-Verbose "$logPrefix Failed to create Catalog"
+            Write-Error $_
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkCatalog = @()
+            $checkCatalog = Get-MgEntitlementManagementCatalog -DisplayNameEq "Catalog-$ServiceName" -ExpandProperty AccessPackages,Resources
+            if((Compare-Object $catalog $checkCatalog|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Catlog object consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject]$catalog
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMCatalogResource.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMCatalogResource.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+    Creates the resources in a catalog
+
+.DESCRIPTION
+    Registers the groups as resources for the catalog
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+
+.PARAMETER ServiceCatalogId
+    The Service Catalog GUID
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMCatalogResource -ServiceGroups $groups -ServiceCatalogId "<GUID>"
+
+#>
+function New-EntraOpsServiceEMCatalogResource {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogId,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $resourceRequests = @()
+        $resources = @()
+        Write-Verbose "$logPrefix Looking up Catalog Resources"
+        try{
+            #Catalog Resource Registration
+            $resourceOptions = @{
+                AccessPackageCatalogId = $ServiceCatalogId
+                ExpandProperty         = @("Roles","Scopes")
+            }
+            $resources += Get-MgEntitlementManagementCatalogResource @resourceOptions
+        }catch{
+            Write-Verbose "$logPrefix Failed to find Catalog Resources"
+            Write-Error $_
+        }
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing $(($ServiceGroups|Measure-Object).Count) Catalog Resources"
+        foreach($group in $ServiceGroups){
+            $resourceRequestParam = @{
+                requestType = "adminAdd"
+                resource    = @{
+                    originId     = $group.Id
+                    originSystem = "AadGroup"
+                }
+                catalog     = @{
+                    id           = $ServiceCatalogId
+                }
+            }
+
+            if($group.DisplayName -notin $resources.DisplayName){
+                $confirmed = $false
+                $i = 0
+                while(-not $confirmed){
+                    Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+                    try{
+                        Write-Verbose "$logPrefix $($group.DisplayName) not found as catalog resource, adding"
+                        $resourceRequests += New-MgEntitlementManagementResourceRequest -BodyParameter $resourceRequestParam -ErrorAction Stop
+                        $confirmed = $true
+                        continue
+                    }catch{
+                        Write-Verbose "$logPrefix Failed to add catalog resource"
+                        if($_.FullyQualifiedErrorId -like "ResourceAlreadyOnboarded*"){
+                            Write-Verbose "$logPrefix Resource already onboarded"
+                            $confirmed = $true
+                            continue
+                        }elseif($_.FullyQualifiedErrorId -like "ResourceNotFoundInOriginSystem*"){
+                            Write-Verbose "$logPrefix group not available in Entitlement Management"
+                            Write-Error $_ -ErrorAction Continue
+                        }else{
+                            Write-Verbose "$logPrefix unknown failure reason, retrying"
+                            Write-Error $_ -ErrorAction Continue
+                        }
+                    }
+                    $i++
+                    if($i -gt 5){
+                        throw "Group object consistency with Entitlement Management not achieved"
+                    }
+                    Write-Verbose "$logPrefix Group objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+                }
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkResources = @()
+            $checkResources = Get-MgEntitlementManagementCatalogResource @resourceOptions
+            if((Compare-Object $ServiceGroups.DisplayName $checkResources.DisplayName|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Catalog Resource object consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkResources
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMCatalogResourceRole.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEMCatalogResourceRole.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Creates catalog resource roles
+
+.DESCRIPTION
+    Creates the roles available for the catalog resources
+
+.PARAMETER ServiceCatalogId
+    The Service Catalog GUID
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceEMCatalogResourceRole -ServiceGroups $groups -ServiceCatalogId "<GUID>"
+
+#>
+function New-EntraOpsServiceEMCatalogResourceRole {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogId,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $catalogAssignments = @()
+        $catalogRolesSplat = @{
+            Filter = "AppScopeId eq '/AccessPackageCatalog/$($ServiceCatalogId)'"
+        }
+
+        try{
+            Write-Verbose "$logPrefix Looking up catalog role assignments"
+            $catalogAssignments += Get-MgRoleManagementEntitlementManagementRoleAssignment @catalogRolesSplat
+        }catch{
+            Write-Verbose "$logPrefix Failed to find catalog role assignments"
+            Write-Error $_
+        }
+
+        $catalogRoles = @"
+displayName,id,filter
+Owner,ae79f266-94d4-4dab-b730-feca7e132178,*Admins-Control
+Reader,44272f93-9762-48e8-af59-1b5351b1d6b3,*Members-Catalog
+ApAssignmentManager,e2182095-804a-4656-ae11-64734e9b7ae5,*Admins-Management
+"@|ConvertFrom-Csv
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing $(($catalogRoles|Measure-Object).Count) catalog resource role assignments"
+        foreach($catalogRole in $catalogRoles){
+            $catalogRoleParams = @{
+                PrincipalId = ($ServiceGroups|Where-Object{$_.DisplayName -like "$($catalogRole.filter)"}).Id
+                RoleDefinitionId = $catalogRole.id
+                AppScopeId = "/AccessPackageCatalog/$($ServiceCatalogId)"
+            }
+
+            try{
+                if(($ServiceGroups|Where-Object{$_.id -eq $catalogRoleParams.PrincipalId}).DisplayName -like $catalogRole.filter){
+                    $nr = $catalogRoleParams.PrincipalId+"_"+$catalogRoleParams.RoleDefinitionId
+                    $er = $catalogAssignments|ForEach-Object{$_.PrincipalId+"_"+$_.RoleDefinitionId}
+                    if($nr -notin $er){
+                        $catalogAssignments += New-MgRoleManagementEntitlementManagementRoleAssignment -BodyParameter $catalogRoleParams
+                    }
+                }
+            }catch{
+                Write-Verbose "$logPrefix Failed to assign catalog roles"
+                Write-Error $_
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkCatalogAssignments = @()
+            $checkCatalogAssignments = Get-MgRoleManagementEntitlementManagementRoleAssignment @catalogRolesSplat
+            if((Compare-Object $catalogAssignments $checkCatalogAssignments|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Catalog Resource Role Assignment consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects are not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkCatalogAssignments
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServiceEntraGroup.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServiceEntraGroup.ps1
@@ -1,0 +1,135 @@
+<#
+.SYNOPSIS
+    Creates an Entra Group based on the provided role
+
+.DESCRIPTION
+    Creates an Entra Group relative to the specific role supplied. Unless for
+    custom implementations, should be used by New-EntraOpsServiceBootstrap.
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER ServiceOwner
+    The Graph URL of a User.
+    "https://graph.microsoft.com/v1.0/users/<ID>"
+
+.PARAMETER ServiceRoles
+    An EntraOps Service Roles object
+
+.PARAMETER logPrefix
+    Prefix used for log messages. Default is current function name.
+
+.EXAMPLE
+    New-EntraOpsServiceEntraGroup -ServiceName "EntraOps" -ServiceOwner $ownerUri -ServiceRoles $roles
+
+    Returns all groups for a specific service
+
+#>
+function New-EntraOpsServiceEntraGroup {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceName,
+
+        [Parameter(Mandatory)]
+        [string]$ServiceOwner,
+
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceRoles,
+
+        [Parameter()]
+        [switch]$IsAssignableToRole,
+
+        [switch]$ProhibitDirectElevation,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        try{
+            #Groups
+            $groups = @()
+            Write-Verbose "$logPrefix Looking up Groups"
+            $groups += Get-MgGroup -Search "MailNickname:$ServiceName." -ConsistencyLevel eventual
+            if(-not $ProhibitDirectElevation){
+                $groups += Get-MgGroup -Search "MailNickname:PIM.$ServiceName." -ConsistencyLevel eventual
+            }
+        }catch{
+            Write-Verbose "$logPrefix Failed processing Groups"
+            Write-Error $_
+        }
+        $groupParams = @{
+            Description = ""
+            SecurityEnabled = $true
+            IsAssignableToRole = $IsAssignableToRole
+            "owners@odata.bind" = @($ServiceOwner)
+        }
+        $unifiedParams = $groupParams + @{
+            DisplayName = ""
+            MailNickname = ""
+            GroupTypes = @("Unified")
+            MailEnabled = $true
+            #"members@odata.bind" = $members
+        }
+        $secParams = $groupParams + @{
+            DisplayName = ""
+            MailNickname = ""
+            MailEnabled = $false
+        }
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing $(($ServiceRoles|Measure-Object).Count) Groups"
+        foreach($ServiceRole in $ServiceRoles){
+            $unifiedParams.Description = "Team $(($ServiceRole.type +" "+ $ServiceRole.name).trim()) supporting $ServiceName"
+            $unifiedParams.DisplayName = "$ServiceName $($ServiceRole.Name)"
+            $unifiedParams.MailNickname = "$ServiceName.$($ServiceRole.Name)"
+            $secParams.Description = "Team $(($ServiceRole.type +" "+ $ServiceRole.name).trim()) supporting $ServiceName"
+            $secParams.DisplayName = "SG-$ServiceName-$($ServiceRole.Name)-$($ServiceRole.type)"
+            $secParams.MailNickname = "$ServiceName.$($ServiceRole.Name +"."+ $ServiceRole.type)"
+            try{
+                if($ServiceRole.groupType -eq "Unified" -and $groups.MailNickname -notcontains $unifiedParams.MailNickname){
+                    Write-Verbose "$logPrefix $($unifiedParams|ConvertTo-Json -Compress)"
+                    $groups += New-MgGroup -BodyParameter $unifiedParams
+                }elseif($ServiceRole.groupType -like "" -and $groups.MailNickname -notcontains $secParams.MailNickname){
+                    Write-Verbose "$logPrefix $($secParams|ConvertTo-Json -Compress)"
+                    $groups += New-MgGroup -BodyParameter $secParams
+                    if($ServiceRole.type -eq "Management" -and $ServiceRole.name -eq "Admins" -and -not $ProhibitDirectElevation){
+                        $secParams.DisplayName = "SG-PIM-$ServiceName-$($ServiceRole.Name)-$($ServiceRole.type)"
+                        $secParams.MailNickname = "PIM.$ServiceName.$($ServiceRole.Name +"."+ $ServiceRole.type)"
+                        $groups += New-MgGroup -BodyParameter $secParams
+                    }
+                }
+            }catch{
+                Write-Verbose "$logPrefix Failed processing Groups"
+                Write-Error $_
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        Write-Verbose "$logPrefix Verifying Groups are available"
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkGroups = @()
+            $checkGroups += Get-MgGroup -Search "MailNickname:$ServiceName." -ConsistencyLevel eventual
+            if(-not $ProhibitDirectElevation){
+                $checkGroups += Get-MgGroup -Search "MailNickname:PIM.$ServiceName." -ConsistencyLevel eventual
+            }
+            if((Compare-Object $groups $checkGroups|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Group object consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects are not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkGroups
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServicePIMAssignment.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServicePIMAssignment.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    Creates Entra PIM assignments
+
+.DESCRIPTION
+    Creates the Entra Privileged Identity Management (PIM) assignments
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServicePIMAssignment -ServiceGroups $groups
+
+#>
+function New-EntraOpsServicePIMAssignment {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $pimEligibilities = @()
+
+        $pimEligibilityParams = @{
+            accessId = "member"
+            principalId = ($ServiceGroups|Where-Object{$_.DisplayName -like "* Members"}).Id
+            groupId = ""
+            action = "AdminAssign"
+            scheduleInfo = @{
+                startDateTime = $((Get-Date).AddHours(-1))
+                expiration = @{
+                    type = "noExpiration"
+                }
+            }
+        }
+    }
+
+    process {
+        foreach($group in $ServiceGroups|Where-Object{$_.DisplayName -notlike "*Members*"}){
+            $pimEligibilityParams.groupId = $group.Id
+            $pimEligibilitySplat = @{
+                Filter = "groupId eq '$($group.Id)'"
+                ExpandProperty = "Group,Principal,TargetSchedule"
+            }
+            Write-Verbose "$logPrefix Looking up eligibility for group ID: $($group.Id)"
+            $pimEligibilities += Get-MgIdentityGovernancePrivilegedAccessGroupEligibilityScheduleRequest @pimEligibilitySplat
+        
+            if($group.DisplayName -like "*-PIM-*"){
+                $pimEligibilityParams.principalId = ($ServiceGroups|Where-Object{$_.DisplayName -like "SG-"+$group.DisplayName.Substring(7)}).Id
+            }
+            $ne = $pimEligibilityParams.principalId+"_noExpiration"
+            $ee = $pimEligibilities|ForEach-Object{$_.PrincipalId+"_"+$_.TargetSchedule.ScheduleInfo.Expiration.Type}
+            if($ne -notin $ee){
+                Write-Verbose "$logPrefix $($pimEligibilityParams|ConvertTo-Json -Compress)"
+                New-MgIdentityGovernancePrivilegedAccessGroupEligibilityScheduleRequest -BodyParameter $pimEligibilityParams|Out-Null
+                $pimEligibilities += Get-MgIdentityGovernancePrivilegedAccessGroupEligibilityScheduleRequest @pimEligibilitySplat
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkPimEligibility = @()
+            foreach($group in $ServiceGroups|Where-Object{$_.DisplayName -notlike "*Members*"}){
+                $pimEligibilitySplat = @{
+                    Filter = "groupId eq '$($group.Id)'"
+                    ExpandProperty = "Group,Principal,TargetSchedule"
+                }
+                $checkPimEligibility += Get-MgIdentityGovernancePrivilegedAccessGroupEligibilityScheduleRequest @pimEligibilitySplat
+            }
+            if((Compare-Object $pimEligibilities.Id $checkPimEligibility.Id|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "Access Package object consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkPimEligibility
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsServicePIMPolicy.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsServicePIMPolicy.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Creates an Entra PIM policy
+
+.DESCRIPTION
+    Creates the Entra Priviliged Identity Management (PIM) policies for
+    the provided groups
+
+.PARAMETER ServiceGroups
+    The Graph Group objects
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServicePIMPolicy -ServiceGroups $groups
+
+#>
+function New-EntraOpsServicePIMPolicy {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject[]]$ServiceGroups,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $groupPolicies = @()
+        $groupPolicyAssignments = @()
+        $groupPolicyParams = @{
+            rules = @(
+                @{
+                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
+                    id = "Expiration_Admin_Eligibility"
+                    isExpirationRequired = $false
+                },
+                @{
+                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
+                    id = "Expiration_Admin_Assignment"
+                    isExpirationRequired = $true
+                    maximumDuration = "P15D"
+                },
+                @{
+                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
+                    id = "Expiration_EndUser_Assignment"
+                    maximumDuration = "PT10H"
+                },
+                @{
+                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyEnablementRule"
+                    id = "Enablement_EndUser_Assignment"
+                    enabledRules = @(
+                        "MultiFactorAuthentication",
+                        "Justification"
+                    )
+                }
+            )
+        }
+    }
+
+    process {
+        foreach($group in $ServiceGroups|Where-Object{$_.DisplayName -notlike "*Members*"}){
+            $groupPolicySplat = @{
+                Filter = "scopeId eq '$($group.Id)' and scopeType eq 'Group'"
+            }
+            try{
+                Write-Verbose "$logPrefix Looking up PIM Policies with Assignments"
+                #$groupPolicy = Get-MgPolicyRoleManagementPolicy @groupPolicySplat -ExpandProperty "Rules,EffectiveRules"
+                $groupPolicyAssignment = Get-MgPolicyRoleManagementPolicyAssignment @groupPolicySplat
+                $groupPolicyAssignments += $groupPolicyAssignment
+            }catch{
+                Write-Verbose "$logPrefix Failed to find PIM Policies with Assignments"
+                Write-Error $_
+            }
+            $memberPolicy = $groupPolicyAssignment|Where-Object{$_.Id -like "*member"}
+            try{
+                Write-Verbose "$logPrefix Updaing PIM Policy ID: $($memberPolicy.PolicyId)"
+                $groupPolicies += Update-MgPolicyRoleManagementPolicy -UnifiedRoleManagementPolicyId $memberPolicy.PolicyId -BodyParameter $groupPolicyParams
+            }catch{
+                Write-Verbose "$logPrefix Failed to update PIM Policy"
+                Write-Error $_
+            }
+        }
+    }
+
+    end {
+        $confirmed = $false
+        $i = 0
+        while(-not $confirmed){
+            Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+            $checkGroupPolicies = @()
+            foreach($group in $ServiceGroups|Where-Object{$_.DisplayName -notlike "*Members*"}){
+                $checkGroupPolicySplat = @{
+                    Filter = "scopeId eq '$($group.Id)' and scopeType eq 'Group'"
+                }
+                $checkGroupPolicyAssignment = Get-MgPolicyRoleManagementPolicyAssignment @checkGroupPolicySplat
+                $checkGroupPolicies += $checkGroupPolicyAssignment|Where-Object{$_.Id -like "*member"}
+            }    
+            if((Compare-Object $groupPolicies.Id $checkGroupPolicies.PolicyId|Measure-Object).Count -eq 0){
+                Write-Verbose "$logPrefix Graph consistency found confirming"
+                $confirmed = $true
+                continue
+            }
+            $i++
+            if($i -gt 5){
+                throw "PIM Policy consistency with Entra not achieved"
+            }
+            Write-Verbose "$logPrefix Graph objects not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+        }
+        return [psobject[]]$checkGroupPolicies
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsSubscriptionLandingZone.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsSubscriptionLandingZone.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Creates the necessary authorization structure for a new service
+
+.DESCRIPTION
+    Creates the foundation for handling authorization of a new service
+    in alignment with the Microsoft Enterprise Access Model.
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceBootstrap
+
+#>
+function New-EntraOpsSubscriptionLandingZone {
+    [OutputType([System.String])]
+    [cmdletbinding()]
+    param(
+        [string[]]$ServiceMembers,
+
+        [string]$ServiceOwner,
+
+        [switch]$OwnerIsNotMember,  
+
+        [switch]$ProhibitDirectElevation,
+
+        [switch]$SkipAzureResourceGroup,
+
+        [string]$AzureRegion = "eastus",
+
+        [string]$DeploymentPrefix = "Default",
+
+        [switch]$Smb,
+
+        [pscustomobject[]]$LandingZoneComponents = @(
+            [pscustomobject]@{
+                Role = "Sub"
+                ServiceRole = @(
+                    [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+                    [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Control"; groupType = ""}
+                )
+            },
+            [pscustomobject]@{
+                Role = "Rg"
+                ServiceRole = @(
+                    [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+                    [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+                    [pscustomobject]@{name = "Users"; type = "Workload"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Workload"; groupType = ""}
+                    #[pscustomobject]@{name = "Admins"; type = "Control"; groupType = ""},
+                    #[pscustomobject]@{name = "Admins"; type = "Management"; groupType = ""}
+                )
+            }
+        ),
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $report = @()
+
+        if($smb){
+            $i = [array]::IndexOf($LandingZoneComponents.Role,"Rg")
+            $LandingZoneComponents[$i].ServiceRole += [pscustomobject]@{name = "Admins"; type = "Management"; groupType = ""}
+        }else{
+            $i = [array]::IndexOf($LandingZoneComponents.Role,"Sub")
+            $LandingZoneComponents[$i].ServiceRole += [pscustomobject]@{name = "Admins"; type = "Management"; groupType = ""}
+        }
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing LZ"
+
+        foreach($component in $LandingZoneComponents){
+            Write-Verbose "$logPrefix Processing LZ Role: $($component.Role)"
+
+            $splatServiceBootstrap = @{
+                ServiceName             = $component.Role + "-" + $DeploymentPrefix
+                OwnerIsNotMember        = $OwnerIsNotMember
+                ProhibitDirectElevation = $ProhibitDirectElevation
+                AzureRegion             = $AzureRegion
+                ServiceRoles            = $component.ServiceRole
+            }
+            if($component.Role -eq "Sub"){
+                $splatServiceBootstrap += @{
+                    ServiceMembers         = $ServiceMembers
+                    ServiceOwner           = $ServiceOwner
+                    SkipAzureResourceGroup = $true
+                }
+            }else{
+                $splatServiceBootstrap += @{
+                    SkipAzureResourceGroup = $SkipAzureResourceGroup
+                }
+            }
+            $report += New-EntraOpsServiceBootstrap @splatServiceBootstrap
+        }
+
+        return $report
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsSubscriptionLandingZoneAlt.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsSubscriptionLandingZoneAlt.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Creates the necessary authorization structure for a new service
+
+.DESCRIPTION
+    Creates the foundation for handling authorization of a new service
+    in alignment with the Microsoft Enterprise Access Model.
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceBootstrap
+
+#>
+function New-EntraOpsSubscriptionLandingZoneAlt {
+    [OutputType([System.String])]
+    [cmdletbinding()]
+    param(
+        [string[]]$ServiceMembers,
+
+        [string]$ServiceOwner,
+
+        [switch]$OwnerIsNotMember,  
+
+        [switch]$ProhibitDirectElevation,
+
+        [switch]$SkipAzureResourceGroup,
+
+        [string]$AzureRegion = "eastus",
+
+        [string]$DeploymentPrefix = "Default",
+
+        [switch]$Smb,
+
+        [pscustomobject[]]$LandingZoneComponents = @(
+            [pscustomobject]@{name = "Admins"; type = "Management"; groupType = ""},
+            [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+            [pscustomobject]@{name = "Admins"; type = "Workload"; groupType = ""},
+            [pscustomobject]@{name = "Members"; type = "Workload"; groupType = ""},
+            [pscustomobject]@{name = "Admins"; type = "Control"; groupType = ""},
+            [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+            [pscustomobject]@{name = "Members"; type = "Catalog"; groupType = ""},
+            [pscustomobject]@{name = "Users"; type = "Workload"; groupType = ""}
+        ),
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $report = @()
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing LZ"
+
+        $splatServiceBootstrap = @{
+            ServiceName             = $DeploymentPrefix
+            OwnerIsNotMember        = $OwnerIsNotMember
+            ProhibitDirectElevation = $ProhibitDirectElevation
+            AzureRegion             = $AzureRegion
+            ServiceRoles            = $LandingZoneComponents
+            ServiceMembers          = $ServiceMembers
+            ServiceOwner            = $ServiceOwner
+            SkipAzureResourceGroup  = $SkipAzureResourceGroup
+        }
+        $report += New-EntraOpsServiceBootstrap @splatServiceBootstrap
+
+        return $report
+    }
+}

--- a/EntraOps/Public/Bootstrap/New-EntraOpsTenantLandingZone.ps1
+++ b/EntraOps/Public/Bootstrap/New-EntraOpsTenantLandingZone.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Creates the necessary authorization structure for a new service
+
+.DESCRIPTION
+    Creates the foundation for handling authorization of a new service
+    in alignment with the Microsoft Enterprise Access Model.
+
+.PARAMETER ServiceName
+    The Name of the Service
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    New-EntraOpsServiceBootstrap
+
+#>
+function New-EntraOpsLandingZone {
+    [OutputType([System.String])]
+    [cmdletbinding()]
+    param(
+        [string[]]$ServiceMembers,
+
+        [string]$ServiceOwner,
+
+        [switch]$OwnerIsNotMember,  
+
+        [switch]$ProhibitDirectElevation,
+
+        [string]$AzureRegion = "eastus",
+
+        [pscustomobject[]]$LandingZoneComponents = @(
+            [pscustomobject]@{
+                Role = "Billing"
+                Components = @(
+                    "Bill-Organization"
+                )
+                ServiceRole = @(
+                    [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+                    [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Management"; groupType = ""}
+                )
+            },
+            [pscustomobject]@{
+                Role = "Mgs"
+                Components = @(
+                    "Tenant Root Group",
+                    "MG-Platform",
+                    "MG-Production",
+                    "MG-Build"
+                )
+                ServiceRole = @(
+                    [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+                    [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Entitlement"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Control"; groupType = ""}
+                )
+            },
+            [pscustomobject]@{
+                Role = "Subs"
+                Components = @(
+                    "Sub-Management",
+                    "Sub-Identity",
+                    "Sub-Connectivity",
+                    "Sub-Prod-Decommissioned",
+                    "Sub-Prod-Platfrom",
+                    "Sub-Prod-App",
+                    "Sub-Build-Decommissioned",
+                    "Sub-Build-Platfrom",
+                    "Sub-Build-App"
+                )
+                ServiceRole = @(
+                    [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+                    [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Control"; groupType = ""}
+                )
+            },
+            [pscustomobject]@{
+                Role = "Rg"
+                Components = @(
+                    "Rg-Default"
+                )
+                ServiceRole = @(
+                    [pscustomobject]@{name = "Members"; type = ""; groupType = "Unified"},
+                    [pscustomobject]@{name = "Members"; type = "Management"; groupType = ""},
+                    [pscustomobject]@{name = "Users"; type = "Workload"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Workload"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Entitlement"; groupType = ""},
+                    [pscustomobject]@{name = "Admins"; type = "Management"; groupType = ""}
+                )
+            }
+        ),
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    begin {
+        $report = @{}
+    }
+
+    process {
+        Write-Verbose "$logPrefix Processing LZ"
+
+        foreach($role in $LandingZoneComponents){
+            Write-Verbose "$logPrefix Processing LZ Role: $($role.Role)"
+            $report|Add-Member -MemberType NoteProperty -Name $role.Role -Value @{}
+            foreach($component in $role.Components){
+                Write-Verbose "$logPrefix Processing LZ Components: $($component)"
+                $report.$($role.Role)|Add-Member -MemberType NoteProperty -Name $component -Value @{}
+                $splatServiceBootstrap = @{
+                    ServiceName = $component
+                    ServiceMembers = $ServiceMembers
+                    ServiceOwner = $ServiceOwner
+                    OwnerIsNotMember = $OwnerIsNotMember
+                    ProhibitDirectElevation = $ProhibitDirectElevation
+                    AzureRegion = $AzureRegion
+                    ServiceRoles = $role.ServiceRole
+                }
+                $report.$($role.Role).$component = New-EntraOpsServiceBootstrap @splatServiceBootstrap
+            }
+        }
+        
+
+        #$report.BillingAccount = New-EntraOpsServiceBootstrap -
+        #$report.
+
+        return $report
+    }
+}

--- a/EntraOps/Public/Bootstrap/Remove-EntraOpsServiceCatalog.ps1
+++ b/EntraOps/Public/Bootstrap/Remove-EntraOpsServiceCatalog.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+    Removes all catalog resources and the catalog itself
+
+.DESCRIPTION
+    Admin removes any assignments, deletes access packages, and deletes the catalog.
+    Must use Force switch.
+
+.PARAMETER ServiceCatalogName
+    The Service Catalog Display Name
+
+.PARAMETER logPrefix
+    Defines the text to prepend for any verbose messages
+
+.EXAMPLE
+    Remove-EntraOpsServiceCatalog -ServiceCatalogName "Catalog" -Force
+
+#>
+function Remove-EntraOpsServiceCatalog {
+    [OutputType([psobject[]])]
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ServiceCatalogName,
+
+        [switch]$Force,
+
+        [string]$logPrefix = "[$($MyInvocation.MyCommand)]"
+    )
+
+    process {
+        if(-not $force){
+            Write-Warning "$logPrefix Catalog and all associated assignments will be deleted, please use -Force switch to proceed"
+            return @{}
+        }
+        $catalog = Get-MgEntitlementManagementCatalog -DisplayNameEq $ServiceCatalogName -ExpandProperty AccessPackages,Resources
+        if(($catalog|Measure-Object).Count -eq 0){
+            Write-Warning "$logPrefix Unable to obtain catalog by name"
+            return @{}
+        }
+        Write-Verbose "$logPrefix Obtained Service Catalog $($catalog.Id)"
+        foreach($accessPackage in $catalog.accessPackages){
+            $assignments=Get-MgEntitlementManagementAssignment -AccessPackageId $accessPackage.Id -ExpandProperty Target
+            foreach($assignment in $assignments|Where-Object{$_.State -ne "expired"}){
+                Write-Verbose "$logPrefix Removing active assignment for $($assignment.Target.DisplayName)[$($assignment.Target.Email)]"
+                $params = @{
+                    requestType = "adminRemove"
+                    assignment  = @{id=$assignment.Id}
+                }
+                $requests=New-MgEntitlementManagementAssignmentRequest -BodyParameter $params
+                $confirmed = $false
+                $i = 0
+                while(-not $confirmed){
+                    Start-Sleep -Seconds ([Math]::Pow(2,$i)-1)
+                    $checkCatalogAssignments = @()
+                    $checkCatalogAssignments += $requests|foreach{Get-MgEntitlementManagementAssignmentRequest -AccessPackageAssignmentRequestId $_.Id}
+                    $fulfilled = $checkCatalogAssignments|Where-Object{$_.Status -ne "Fulfilled"}|Measure-Object
+                    if($fulfilled.Count -ne ($checkCatalogAssignments|Measure-Object).Count){
+                        Write-Verbose "$logPrefix Graph consistency found confirming"
+                        $confirmed = $true
+                        continue
+                    }
+                    $i++
+                    if($i -gt 9){
+                        throw "Role assignment requests not processed"
+                    }
+                    Write-Verbose "$logPrefix Graph objects are not available, sleeping $([Math]::Pow(2,$i)-1) seconds"
+                }
+            }
+            Write-Verbose "$logPrefix Deleting $($accessPackage.DisplayName)[$($accessPackage.Id)]"
+            Remove-MgEntitlementManagementAccessPackage -AccessPackageId $accessPackage.Id
+        }
+        Write-Verbose "$logPrefix Deleting Catalog"
+        Remove-MgEntitlementManagementCatalog -AccessPackageCatalogId $catalog.Id
+    }
+
+    end {
+        return @{}
+    }
+}


### PR DESCRIPTION
This is a clean reset of the original concept from #32.

The core functionality of this PR provides:
- Individual functions (New-EntraOpsServiceAZ/EM/Entra/PIM*) to interact with core Entitlement Management (EM) capabilities for validating and creating new resources.
- A bootstrap function (`New-EntraOpsServiceBootstrap) to wrap the individual functions and provide a single processor for all EM resource creation in the intent of supporting a new "service".
- An example of using the bootstrap function for a new Azure Subscription Landing Zone (`New-EntraOpsSubscriptionLandingZoneAlt`).
- The ability to generate a report object (`Get-EntraOpsReport`) and convert that report object to a Mermaid diagram (`ConvertTo-Mermaid`).
- The ability to bulk remove an EM Catalog and all resources (`Remove-EntraOpsServiceCatalog`).

> As a note, EM Assignments can take minutes to process. Use -Verbose to see the status of backoff retries against the API.

The bootstrap functionality uses the following Azure & Graph Modules:
`Microsoft.Graph.Users, Microsoft.Graph.Authentication, Microsoft.Graph.Groups, Microsoft.Graph.Identity.Governance, Microsoft.Graph.Identity.SignIns, Microsoft.Graph.Identity.Governance, Az.Accounts, Az.Resources`

The bootstrap functionality uses the following Graph scopes:
`Directory.AccessAsUser.All, EntitlementManagement.ReadWrite.All, RoleManagementPolicy.ReadWrite.AzureADGroup, RoleManagementPolicy.ReadWrite.Directory, RoleManagement.ReadWrite.Directory, PrivilegedEligibilitySchedule.ReadWrite.AzureADGroup, PrivilegedAccess.ReadWrite.AzureADGroup`

Quick start, these three lines will set the service member and service owner and bootstrap the minimal Entra resources for a Subscription Landing Zone. Including:
- 1 M365 Group, Default Members
- 7 Security Groups (SG), SG-Default-*
- 1 EM Catalog, Catalog-Default
  - All 8 group objects are registered resources for the catalog
  - The SG-Default-Admins-Control group is Catalog owner
  - The SG-Default-Members-Catalog group is Catalog reader
  - The SG-Default-Admins-Management group is Access package assignment manager
  - There are 7 Access Packages (AP) created, one for each SG
- Each AP has a resource assignment to the corresponding SG
  - With the Default Members M365 Group assigned to the AP-Default-Users-Workload
- Each AP has at least one assignment policy associated for time bound and approval requirements
  - AP-Default-Admins-Management has a second policy for initial assignment of admin inheritance
- The Service Members inherits an assignment to AP-Default-Members-Workload.
- The Service Owner inherits an assignment to AP-Default-Admins-Management.

```
$serviceMember = "AlexW@M365x96579414.OnMicrosoft.com"
$serviceOwner = "AdeleV@M365x96579414.OnMicrosoft.com"
$service = New-EntraOpsSubscriptionLandingZoneAlt -SkipAzureResourceGroup -ProhibitDirectElevation -ServiceMembers $serviceMember -ServiceOwner $serviceOwner
```

To visualize the created EM resources you can run the following commands then use a Mermaid visualizer, such as https://mermaid.live/. The bootstrap example is included here for reference as well.

```
$report = Get-EntraOpsReport
ConvertTo-Mermaid -ReportObject $report|clip
```

```mermaid
graph
  subgraph ce00f510-ca43-496d-a403-b83bd960bdbb [Catalog-Default]

    subgraph ce00f510-ca43-496d-a403-b83bd960bdbbRoles [Roles]
      6b00960b-fc09-4dc3-8313-037ce7db74e2(Catalog owner - SG-Default-Admins-Control)
      163e73b2-f5ee-4c52-a4bc-117e45fe952f(Catalog reader - SG-Default-Members-Catalog)
      28fc3a3d-839f-4544-9f9a-4888f708aac3(AccessPackage assignment manager - SG-Default-Admins-Management)
    end

    subgraph ce00f510-ca43-496d-a403-b83bd960bdbbResources [Resources]
      0d6ba2e8-9251-4839-86c6-af1187007513(SG-Default-Admins-Management)
      a9f7c14a-ee2b-4889-82ba-dc9409923c7c(Default Members)
      b26be3da-af7c-44dd-9f42-cf0ed4d809ef(SG-Default-Users-Workload)
      c97ad1ec-885a-4fe3-b2f5-d2691dad892d(SG-Default-Members-Catalog)
      de34e320-669a-478d-9b77-a8f1311af12f(SG-Default-Members-Management)
      e452f18c-e827-47fa-b9db-a11ae6f87843(SG-Default-Admins-Workload)
      e7f366ec-8010-4d6b-8eb9-04c89e0fd499(SG-Default-Members-Workload)
      ee901010-207e-48ef-b0bd-a7d0e14ca8e7(SG-Default-Admins-Control)
    end

    subgraph ce00f510-ca43-496d-a403-b83bd960bdbbAccessPackages [Access Packages]
      subgraph a5adb840-76ec-464c-8414-798b8ecedc12 [AP-Default-Users-Workload]
        18ee1718-ca1e-4b9d-b23c-debabac80a79(Baseline Policy)
      end
      subgraph db6e7a67-c336-4ebb-8d5f-4ccb76643895 [AP-Default-Members-Catalog]
        10120df6-17b8-45df-84e2-1f946d5c1dd2(Baseline Policy)
      end
      subgraph bd05df2f-0ab2-4021-9f34-bce28f439cad [AP-Default-Admins-Control]
        e9bf7db3-645c-4f28-b735-94633f9cabee(Baseline Policy)
      end
      subgraph 402de51c-2104-4376-96d2-d15ac3613099 [AP-Default-Members-Workload]
        744063ae-8c9e-4145-89d2-24a3371e9044(Initial Workload Membership Policy)
      end
      subgraph 74215264-4977-49d5-b81c-b3903c2ae06f [AP-Default-Admins-Workload]
        75d02a7d-61d0-4246-ac9f-2fe85d6698a3(Workload Plane Policy)
      end
      subgraph badbfea9-87d8-41b1-b49f-9d8dc1480bbc [AP-Default-Members-Management]
        564f9f2d-5969-44f4-a07c-1e6759523c86(Initial Management Membership Policy)
      end
      subgraph b845643c-3a38-491c-a5c7-3ff2cd173ed2 [AP-Default-Admins-Management]
        5fe3f349-011b-40b4-85c8-68d917e7e696(Management Plane Policy)
        056d8e94-0020-44e5-88af-f782e0140269(Initial Management Admin Policy)
      end
    end
  end

82754626-d53c-4469-b411-a7abf99f3316(Alex Wilber)
9391e1a9-6a0d-42f2-9289-9d66983bea4f(Adele Vance)

9391e1a9-6a0d-42f2-9289-9d66983bea4f --> 056d8e94-0020-44e5-88af-f782e0140269
9391e1a9-6a0d-42f2-9289-9d66983bea4f --> 744063ae-8c9e-4145-89d2-24a3371e9044
82754626-d53c-4469-b411-a7abf99f3316 --> 744063ae-8c9e-4145-89d2-24a3371e9044

c97ad1ec-885a-4fe3-b2f5-d2691dad892d --> 18ee1718-ca1e-4b9d-b23c-debabac80a79
c97ad1ec-885a-4fe3-b2f5-d2691dad892d --> 10120df6-17b8-45df-84e2-1f946d5c1dd2
c97ad1ec-885a-4fe3-b2f5-d2691dad892d --> e9bf7db3-645c-4f28-b735-94633f9cabee
e7f366ec-8010-4d6b-8eb9-04c89e0fd499 --> 75d02a7d-61d0-4246-ac9f-2fe85d6698a3
e7f366ec-8010-4d6b-8eb9-04c89e0fd499 --> 564f9f2d-5969-44f4-a07c-1e6759523c86
5fe3f349-011b-40b4-85c8-68d917e7e696 --> 056d8e94-0020-44e5-88af-f782e0140269

a5adb840-76ec-464c-8414-798b8ecedc12 --> b26be3da-af7c-44dd-9f42-cf0ed4d809ef
a5adb840-76ec-464c-8414-798b8ecedc12 --> a9f7c14a-ee2b-4889-82ba-dc9409923c7c
db6e7a67-c336-4ebb-8d5f-4ccb76643895 --> c97ad1ec-885a-4fe3-b2f5-d2691dad892d
bd05df2f-0ab2-4021-9f34-bce28f439cad --> ee901010-207e-48ef-b0bd-a7d0e14ca8e7
402de51c-2104-4376-96d2-d15ac3613099 --> e7f366ec-8010-4d6b-8eb9-04c89e0fd499
74215264-4977-49d5-b81c-b3903c2ae06f --> e452f18c-e827-47fa-b9db-a11ae6f87843
badbfea9-87d8-41b1-b49f-9d8dc1480bbc --> de34e320-669a-478d-9b77-a8f1311af12f
b845643c-3a38-491c-a5c7-3ff2cd173ed2 --> 0d6ba2e8-9251-4839-86c6-af1187007513

ee901010-207e-48ef-b0bd-a7d0e14ca8e7 --> 6b00960b-fc09-4dc3-8313-037ce7db74e2
c97ad1ec-885a-4fe3-b2f5-d2691dad892d --> 163e73b2-f5ee-4c52-a4bc-117e45fe952f
0d6ba2e8-9251-4839-86c6-af1187007513 --> 28fc3a3d-839f-4544-9f9a-4888f708aac3
```

To cleanup the created EM resources easily you can run the following command, note that this does NOT delete the Entra group objects.

```
Remove-EntraOpsServiceCatalog -ServiceCatalogName "Catalog-Default" -Force
```