### PR TITLE
Fix: Control Plane scope, CA group sync, Graph API, and warning noise

### DIFF
--- a/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
+++ b/EntraOps/Public/Configuration/New-EntraOpsConfigFile.ps1
@@ -52,8 +52,11 @@ function New-EntraOpsConfigFile {
         [ValidateSet('AzureDevOps', 'GitHub', 'None')]
         [string]$DevOpsPlatform = "GitHub",
 
+        # Removed ValidateScript({ Test-Path $_ }) - this cmdlet creates the config file,
+        # so the path will not exist yet when the parameter is validated. Validate the
+        # parent directory instead to catch typos without blocking new file creation.
         [Parameter(Mandatory = $false)]
-        [ValidateScript({ Test-Path $_ })]
+        [ValidateScript({ Test-Path (Split-Path $_ -Parent) })]
         [string]$ConfigFilePath = "$EntraOpsBasefolder/EntraOpsConfig.json",
 
         [Parameter(Mandatory = $false)]

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsClassificationControlPlaneObjects.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsClassificationControlPlaneObjects.ps1
@@ -75,8 +75,11 @@ function Get-EntraOpsClassificationControlPlaneObjects {
         [Parameter(Mandatory = $false)]
         [System.String]$EntraIdCustomizedClassificationFile = "$DefaultFolderClassification\$($TenantNameContext)\Classification_AadResources.json"
         ,
+        # Removed ValidateScript({ Test-Path $_ }) - on first run, the PrivilegedEAM/
+        # directory does not exist yet because Save-EntraOpsPrivilegedEAMJson has not
+        # been called. Missing data files are already handled gracefully below in the
+        # try/catch around Get-Content with a Write-Warning for each missing scope.
         [Parameter(Mandatory = $false)]
-        [ValidateScript({ Test-Path $_ })]
         [string]$EntraOpsEamFolder = "$DefaultFolderClassifiedEam"
         ,
         [Parameter(Mandatory = $false)]

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedDefenderRoles.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedDefenderRoles.ps1
@@ -175,7 +175,7 @@ function Get-EntraOpsPrivilegedDefenderRoles {
                     }
                 }
             } else {
-                Write-Warning "Empty group $($RbacAssignmentByGroup.ObjectId)"
+                Write-Verbose "Skipping group '$($RbacAssignmentByGroup.ObjectDisplayName)' ($($RbacAssignmentByGroup.ObjectId)) - no transitive members found for role '$($RbacAssignmentByGroup.RoleName)'"
             }
 
             $DefenderTransitiveRbacAssignments.Add($TransitiveMember) | Out-Null

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedDeviceRoles.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedDeviceRoles.ps1
@@ -181,7 +181,7 @@ function Get-EntraOpsPrivilegedDeviceRoles {
                     }
                 }
             } else {
-                Write-Warning "Empty group $($RbacAssignmentByGroup.ObjectId)"
+                Write-Verbose "Skipping group '$($RbacAssignmentByGroup.ObjectDisplayName)' ($($RbacAssignmentByGroup.ObjectId)) - no transitive members found for role '$($RbacAssignmentByGroup.RoleName)'"
             }
 
             $DeviceMgmtTransitiveRbacAssignments.Add($TransitiveMember) | Out-Null

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMDefender.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMDefender.ps1
@@ -85,19 +85,22 @@ function Get-EntraOpsPrivilegedEamDefender {
         # Check if RBAC scope is listed in JSON by wildcard in RoleAssignmentScope (e.g. /azops-rg/*)
         $MatchedClassificationByScope += $DefenderResourcesByClassificationJSON | foreach-object {
             $Classification = $_
-            $Classification | where-object { $DefenderRbacAssignment.RoleAssignmentScopeId -like $Classification.RoleAssignmentScopeName -and $DefenderRbacAssignment.RoleAssignmentScopeId -notcontains $Classification.ExcludedRoleAssignmentScopeName }
+            # Fixed: reversed -notcontains operands — the exclusion list should be on the left side.
+            $Classification | where-object { $DefenderRbacAssignment.RoleAssignmentScopeId -like $Classification.RoleAssignmentScopeName -and $Classification.ExcludedRoleAssignmentScopeName -notcontains $DefenderRbacAssignment.RoleAssignmentScopeId }
         }
 
         # Check if role action and scope exists in JSON definition
         $DefenderRoleActionsInJsonDefinition = @()
         $DefenderRoleActionsInJsonDefinition = foreach ($Action in $DefenderRoleActions.rolePermissions.allowedResourceActions) {
-            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $Classification.ExcludedRoleDefinitionActions -notcontains $_.RoleDefinitionActions }
+            # Fixed: stale $Classification variable and wrong exclusion check target.
+            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $_.ExcludedRoleDefinitionActions -notcontains $Action }
         }
 
         if (($DefenderRoleActionsInJsonDefinition.Count -gt 0)) {
             $ClassifiedDefenderMgmtRbacRoleWithActions = @()
             foreach ($DefenderRoleAction in $DefenderRoleActions.rolePermissions.allowedResourceActions) {
-                $ClassifiedDefenderMgmtRbacRoleWithActions += $DefenderResourcesByClassificationJSON | Where-Object { $DefenderRoleAction -in $_.RoleDefinitionActions -and $_.RoleAssignmentScopeName -contains $DefenderRbacAssignment.RoleAssignmentScopeId -and $_.ExcludedRoleAssignmentScopeName -notcontains $DefenderRbacAssignment.RoleAssignmentScopeId }
+                # Fixed: use -like for wildcard scope matching and -notin for exclusion check.
+                $ClassifiedDefenderMgmtRbacRoleWithActions += $DefenderResourcesByClassificationJSON | Where-Object { $DefenderRoleAction -in $_.RoleDefinitionActions -and $DefenderRbacAssignment.RoleAssignmentScopeId -like $_.RoleAssignmentScopeName -and $DefenderRbacAssignment.RoleAssignmentScopeId -notin $_.ExcludedRoleAssignmentScopeName }
             }
             $ClassifiedDefenderMgmtRbacRoleWithActions = $ClassifiedDefenderMgmtRbacRoleWithActions | select-object -Unique EAMTierLevelName, EAMTierLevelTagValue, Service
             $Classification = $ClassifiedDefenderMgmtRbacRoleWithActions | ForEach-Object {

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMEntraId.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMEntraId.ps1
@@ -147,7 +147,9 @@ function Get-EntraOpsPrivilegedEamEntraId {
         $CurrentAadRbacClassification.Classification = New-Object System.Collections.ArrayList
 
         if ($ControlPlaneRolesWithoutRoleActions.RoleId -contains $CurrentAadRbacClassification.RoleDefinitionId) {
-            Write-Warning "Apply classification for role $($CurrentAadRbacClassification.RoleDefinitionName) without role actions..."
+            # Use Verbose instead of Warning — this fires per role assignment, not per role definition,
+            # so roles assigned to many principals (e.g. Privileged Auth Admin) produce excessive duplicates.
+            Write-Verbose "Apply classification for role $($CurrentAadRbacClassification.RoleDefinitionName) without role actions..."
             $Classification = $ControlPlaneRolesWithoutRoleActions | Where-Object { $_.RoleId -contains $CurrentAadRbacClassification.RoleDefinitionId }
             $ClassifiedAadRbacRoleWithoutActions = [PSCustomObject]@{
                 'AdminTierLevel'     = "0"

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMEntraId.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMEntraId.ps1
@@ -119,7 +119,10 @@ function Get-EntraOpsPrivilegedEamEntraId {
     if ($SampleMode -eq $True) {
         $AllAadRoleActions = get-content -Path "$EntraOpsBaseFolder/Samples/AadRoleManagementRoleDefinitions.json" | ConvertFrom-Json -Depth 10
     } else {
-        $AllAadRoleActions = (Invoke-EntraOpsMsGraphQuery -Method Get -Uri "https://graph.microsoft.com/v1.0/roleManagement/directory/roleDefinitions" -OutputType PSObject)
+        # Use beta endpoint — some roles (e.g. Modern Commerce User, AdHoc License Administrator,
+        # Email Verified User Creator) only exist in beta, not v1.0. Role assignments are collected
+        # from beta, so role definitions must use the same API version to avoid classification gaps.
+        $AllAadRoleActions = (Invoke-EntraOpsMsGraphQuery -Method Get -Uri "https://graph.microsoft.com/beta/roleManagement/directory/roleDefinitions" -OutputType PSObject)
     }
     #endregion
 
@@ -141,7 +144,10 @@ function Get-EntraOpsPrivilegedEamEntraId {
         # Check if role action and scope exists in JSON definition
         $AadRoleActionsInJsonDefinition = @()
         $AadRoleActionsInJsonDefinition = foreach ($Action in $AadRoleActions.rolePermissions.allowedResourceActions) {
-            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $Classification.ExcludedRoleDefinitionActions -notcontains $_.RoleDefinitionActions }
+            # Fixed: was using stale $Classification from the previous foreach-object pipeline (line 137),
+            # which retained the last entry's ExcludedRoleDefinitionActions. Use $_ to reference each
+            # matched classification entry's own exclusion list.
+            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $_.ExcludedRoleDefinitionActions -notcontains $Action }
         }
 
         $CurrentAadRbacClassification.Classification = New-Object System.Collections.ArrayList

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMIdGov.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMIdGov.ps1
@@ -185,7 +185,8 @@ function Get-EntraOpsPrivilegedEamIdGov {
         # Check if role action and scope exists in JSON definition
         $IdGovRoleActionsInJsonDefinition = @()
         $IdGovRoleActionsInJsonDefinition = foreach ($Action in $IdGovRoleActions.rolePermissions.allowedResourceActions) {
-            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $Classification.ExcludedRoleDefinitionActions -notcontains $_.RoleDefinitionActions }
+            # Fixed: stale $Classification variable and wrong exclusion check target.
+            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $_.ExcludedRoleDefinitionActions -notcontains $Action }
         }
 
 

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMIntune.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEAMIntune.ps1
@@ -197,20 +197,24 @@ function Get-EntraOpsPrivilegedEamIntune {
         # Check if RBAC scope is listed in JSON by wildcard in RoleAssignmentScope (e.g. /azops-rg/*)
         $MatchedClassificationByScope += $IntuneResourcesByClassificationJSON | foreach-object {
             $Classification = $_
-            $Classification | where-object { $DeviceMgmtRbacAssignment.RoleAssignmentScopeId -like $Classification.RoleAssignmentScopeName -and $DeviceMgmtRbacAssignment.RoleAssignmentScopeId -notcontains $Classification.ExcludedRoleAssignmentScopeName }
+            # Fixed: reversed -notcontains operands — the exclusion list should be on the left side.
+            $Classification | where-object { $DeviceMgmtRbacAssignment.RoleAssignmentScopeId -like $Classification.RoleAssignmentScopeName -and $Classification.ExcludedRoleAssignmentScopeName -notcontains $DeviceMgmtRbacAssignment.RoleAssignmentScopeId }
         }
 
         # Check if role action and scope exists in JSON definition
         $IntuneRoleActionsInJsonDefinition = @()
         $IntuneRoleActionsInJsonDefinition = foreach ($Action in $IntuneRoleActions.rolePermissions.allowedResourceActions) {
-            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $Classification.ExcludedRoleDefinitionActions -notcontains $_.RoleDefinitionActions }
+            # Fixed: stale $Classification variable and wrong exclusion check target.
+            $MatchedClassificationByScope | Where-Object { $_.RoleDefinitionActions -Contains $Action -and $_.ExcludedRoleDefinitionActions -notcontains $Action }
         }
 
 
         if (($IntuneRoleActionsInJsonDefinition.Count -gt 0)) {
             $ClassifiedDeviceMgmtRbacRoleWithActions = @()
             foreach ($IntuneRoleAction in $IntuneRoleActions.rolePermissions.allowedResourceActions) {
-                $ClassifiedDeviceMgmtRbacRoleWithActions += $IntuneResourcesByClassificationJSON | Where-Object { $IntuneRoleAction -in $_.RoleDefinitionActions -and $_.RoleAssignmentScopeName -contains $DeviceMgmtRbacAssignment.RoleAssignmentScopeId -and $_.ExcludedRoleAssignmentScopeName -notcontains $DeviceMgmtRbacAssignment.RoleAssignmentScopeId }
+                # Fixed: use -like for wildcard scope matching (consistent with first pass on line 200)
+                # and -notin for exclusion check (consistent with EntraID/IdGov pattern).
+                $ClassifiedDeviceMgmtRbacRoleWithActions += $IntuneResourcesByClassificationJSON | Where-Object { $IntuneRoleAction -in $_.RoleDefinitionActions -and $DeviceMgmtRbacAssignment.RoleAssignmentScopeId -like $_.RoleAssignmentScopeName -and $DeviceMgmtRbacAssignment.RoleAssignmentScopeId -notin $_.ExcludedRoleAssignmentScopeName }
             }
             $ClassifiedDeviceMgmtRbacRoleWithActions = $ClassifiedDeviceMgmtRbacRoleWithActions | select-object -Unique EAMTierLevelName, EAMTierLevelTagValue, Service
             $Classification = $ClassifiedDeviceMgmtRbacRoleWithActions | ForEach-Object {

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEntraIdRoles.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEntraIdRoles.ps1
@@ -289,7 +289,7 @@ function Get-EntraOpsPrivilegedEntraIdRoles {
                     }
                 }
             } else {
-                Write-Warning "Empty group $($RbacAssignmentByGroup.ObjectId)"
+                Write-Verbose "Skipping group '$($RbacAssignmentByGroup.ObjectDisplayName)' ($($RbacAssignmentByGroup.ObjectId)) - no transitive members found for role '$($RbacAssignmentByGroup.RoleName)'"
             }
 
             $AadRbacTransitiveAssignments.Add($TransitiveMember) | Out-Null

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEntraObject.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedEntraObject.ps1
@@ -171,8 +171,9 @@ function Get-EntraOpsPrivilegedEntraObject {
             }
             $OutsideOfAadTenant = $false
 
-            # Owners
-            Invoke-EntraOpsMsGraphQuery -Method Get -Uri ("/beta/serviceprincipals/$AadObjectId/owners") -OutputType PSObject | ForEach-Object { $Owners.Add($_.id) | out-null }
+            # Owners — was incorrectly calling /serviceprincipals/{id}/owners for group objects,
+            # causing NotFound errors for every group. Groups use the /groups/{id}/owners endpoint.
+            Invoke-EntraOpsMsGraphQuery -Method Get -Uri ("/beta/groups/$AadObjectId/owners") -OutputType PSObject | ForEach-Object { $Owners.Add($_.id) | out-null }
 
             # No support for custom security attributes
             $AdminTierLevel = ""

--- a/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedIdGovRoles.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Get-EntraOpsPrivilegedIdGovRoles.ps1
@@ -146,7 +146,7 @@ function Get-EntraOpsPrivilegedIdGovRoles {
                     }
                 }
             } else {
-                Write-Warning "Empty group $($RbacAssignmentByGroup.ObjectId)"
+                Write-Verbose "Skipping group '$($RbacAssignmentByGroup.ObjectDisplayName)' ($($RbacAssignmentByGroup.ObjectId)) - no transitive members found for role '$($RbacAssignmentByGroup.RoleName)'"
             }
 
             $ElmRbacTransitiveAssignments.Add($TransitiveMember) | Out-Null

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
@@ -217,6 +217,8 @@ function Update-EntraOpsClassificationControlPlaneScope {
         $AppIds = @()
         $AppIds += ($PrivilegedServicePrincipals | Where-Object { $null -ne $_.ObjectUserPrincipalName -and $_.ObjectSubType -eq "Application" }).ObjectUserPrincipalName
         $AppIds += ($PrivilegedServicePrincipals | Where-Object { $null -ne $_.ObjectSignInName -and $_.ObjectSubType -eq "Application" }).ObjectSignInName
+        # Filter out null or empty AppIds to avoid BadRequest errors from applications(appId='')
+        $AppIds = $AppIds | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
 
         # Get application object IDs for service principals because directory role assignments can be assigned to application objects
         $ScopeNameApplicationObject = $AppIds | ForEach-Object {

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
@@ -77,8 +77,12 @@ function Update-EntraOpsClassificationControlPlaneScope {
         [Parameter(Mandatory = $false)]
         [System.String]$EntraIdCustomizedClassificationFile = "$DefaultFolderClassification\$($TenantNameContext)\Classification_AadResources.json"
         ,
+        # Removed ValidateScript({ Test-Path $_ }) - on first run, the PrivilegedEAM/
+        # directory does not exist yet because Save-EntraOpsPrivilegedEAMJson has not
+        # been called. This causes the workflow to fail before any data is collected.
+        # The inner Get-EntraOpsClassificationControlPlaneObjects already handles
+        # missing files gracefully with try/catch and Write-Warning.
         [Parameter(Mandatory = $false)]
-        [ValidateScript({ Test-Path $_ })]
         [string]$EntraOpsEamFolder = "$DefaultFolderClassifiedEam"
         ,
         [Parameter(Mandatory = $false)]

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
@@ -110,12 +110,12 @@ function Update-EntraOpsClassificationControlPlaneScope {
         PrivilegedObjectIds                  = $PrivilegedObjectIds
     }
 
-    $PrivilegedObjects = Get-EntraOpsClassificationControlPlaneObjects @Parameters
+    [array]$PrivilegedObjects = Get-EntraOpsClassificationControlPlaneObjects @Parameters
 
     #region Get classification file and filter for unique privileged objects
     $DirectoryLevelAssignmentScope = @("/")
     $EntraIdRoleClassification = Get-Content -Path $EntraIdClassificationParameterFile
-    $PrivilegedObjects = $PrivilegedObjects | sort-object ObjectType, ObjectDisplayName | Select-Object -Unique *
+    [array]$PrivilegedObjects = $PrivilegedObjects | sort-object ObjectType, ObjectDisplayName | Select-Object -Unique *
     Write-Output "Identified privileged objects:"
     $PrivilegedObjects | ForEach-Object {
         
@@ -126,12 +126,12 @@ function Update-EntraOpsClassificationControlPlaneScope {
 
     #region Privileged User
     Write-Output "Identify directory role scope of privileged users..."
-    $PrivilegedUsersWithoutProtection = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and ($_.RestrictedManagementByRAG -eq $false -and $_.RestrictedManagementByAadRole -eq $False -and $RestrictedManagementByRMAU -eq $False) }
+    [array]$PrivilegedUsersWithoutProtection = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and ($_.RestrictedManagementByRAG -eq $false -and $_.RestrictedManagementByAadRole -eq $False -and $_.RestrictedManagementByRMAU -eq $False) }
 
     # Include all Administrative Units because of Privileged Authentication Admin role assignment on (RM)AU level
-    $PrivilegedUserWithAU = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and $null -ne $_.AssignedAdministrativeUnits }
-    $ScopeNamePrivilegedUsers = $PrivilegedUserWithAU.AssignedAdministrativeUnits | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
-    if ($PrivilegedUsersWithoutProtection -gt "0") {
+    [array]$PrivilegedUserWithAU = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and $null -ne $_.AssignedAdministrativeUnits }
+    [array]$ScopeNamePrivilegedUsers = $PrivilegedUserWithAU.AssignedAdministrativeUnits | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
+    if ($PrivilegedUsersWithoutProtection.Count -gt 0) {
         Write-Warning "Control Plane user without any protection, requires to avoid directory role assignments for user management!"
         Write-Host $PrivilegedUsersWithoutProtection
         $ScopeNamePrivilegedUsers += $DirectoryLevelAssignmentScope
@@ -150,14 +150,14 @@ function Update-EntraOpsClassificationControlPlaneScope {
 
     #region Privileged Devices
     Write-Output "Identify directory role scope of privileged devices..."
-    $PrivilegedUsersWithDevices = ($PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and $null -ne $_.OwnedDevices }) | Select-Object -ExpandProperty OwnedDevices | Select-Object -Unique
-    $PrivilegedDevicesAUs = $PrivilegedUsersWithDevices | ForEach-Object {
+    [array]$PrivilegedUsersWithDevices = ($PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and $null -ne $_.OwnedDevices }) | Select-Object -ExpandProperty OwnedDevices | Select-Object -Unique
+    [array]$PrivilegedDevicesAUs = $PrivilegedUsersWithDevices | ForEach-Object {
         @(Invoke-EntraOpsMsGraphQuery -Method Get -Uri "/beta/devices/$($_)/memberOf/microsoft.graph.administrativeUnit" -OutputType PSObject | Select-Object id, displayName, isMemberManagementRestricted)
     }
-    $PrivilegedDevicesWithoutProtection = $PrivilegedDevicesAUs | Where-Object { $_.isMemberManagementRestricted -eq $False } | Select-Object -Unique id
-    $ScopeNamePrivilegedDevices = $PrivilegedDevicesAUs | Where-Object { $_.isMemberManagementRestricted -eq $True } | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
+    [array]$PrivilegedDevicesWithoutProtection = $PrivilegedDevicesAUs | Where-Object { $_.isMemberManagementRestricted -eq $False } | Select-Object -Unique id
+    [array]$ScopeNamePrivilegedDevices = $PrivilegedDevicesAUs | Where-Object { $_.isMemberManagementRestricted -eq $True } | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
 
-    if ($PrivilegedDevicesWithoutProtection -gt "0") {
+    if ($PrivilegedDevicesWithoutProtection.Count -gt 0) {
         Write-Warning "Control Plane devices without any protection, requires to avoid directory role assignments for device object management!"
         Write-Host $PrivilegedDevicesWithoutProtection
         $ScopeNamePrivilegedDevices += $DirectoryLevelAssignmentScope
@@ -175,10 +175,10 @@ function Update-EntraOpsClassificationControlPlaneScope {
 
     #region Privileged Groups
     Write-Output "Identify directory role scope of privileged groups..."
-    $PrivilegedGroupsWithoutProtection = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "user" -and ($_.RestrictedManagementByRAG -eq $false -and $RestrictedManagementByRMAU -eq $False) }
-    $PrivilegedGroupWithRMAU = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "group" -and $_.RestrictedManagementByRMAU -eq $True }
-    $ScopeNamePrivilegedGroups = $PrivilegedGroupWithRMAU.AssignedAdministrativeUnits | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
-    if ($PrivilegedGroupsWithoutProtection -eq "0") {
+    [array]$PrivilegedGroupsWithoutProtection = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "group" -and ($_.RestrictedManagementByRAG -eq $false -and $_.RestrictedManagementByRMAU -eq $False) }
+    [array]$PrivilegedGroupWithRMAU = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "group" -and $_.RestrictedManagementByRMAU -eq $True }
+    [array]$ScopeNamePrivilegedGroups = $PrivilegedGroupWithRMAU.AssignedAdministrativeUnits | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
+    if ($PrivilegedGroupsWithoutProtection.Count -gt 0) {
         Write-Warning "Control Plane group without any protection, requires to avoid directory role assignments for group management!"
         $ScopeNamePrivilegedGroups += $DirectoryLevelAssignmentScope
     }
@@ -196,8 +196,9 @@ function Update-EntraOpsClassificationControlPlaneScope {
 
     #region Privileged Service Principals
     Write-Output "Identify directory role scope of service principals and application objects..."
-    $PrivilegedServicePrincipals = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "servicePrincipal" }
-    if ($PrivilegedServicePrincipals.Count -gt "0") {
+    [array]$PrivilegedServicePrincipals = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "servicePrincipal" }
+    [array]$ScopeNamePrivilegedServicePrincipals = @()
+    if ($PrivilegedServicePrincipals.Count -gt 0) {
         # Get list of object-level role assignment scope which includes Control Plane Service Principals
         $ScopeNameServicePrincipalObject = $PrivilegedServicePrincipals | ForEach-Object { "/$($_.ObjectId)" }
 

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsClassificationControlPlaneScope.ps1
@@ -110,6 +110,8 @@ function Update-EntraOpsClassificationControlPlaneScope {
         PrivilegedObjectIds                  = $PrivilegedObjectIds
     }
 
+    # [array] cast ensures single-object pipeline results retain array behavior,
+    # which is required for .Count checks and consistent iteration below.
     [array]$PrivilegedObjects = Get-EntraOpsClassificationControlPlaneObjects @Parameters
 
     #region Get classification file and filter for unique privileged objects
@@ -175,6 +177,9 @@ function Update-EntraOpsClassificationControlPlaneScope {
 
     #region Privileged Groups
     Write-Output "Identify directory role scope of privileged groups..."
+    # Fix: Was filtering ObjectType -eq "user" which meant unprotected privileged groups were never detected.
+    # Fix: Was using -eq "0" (inverted logic) which triggered the warning when zero unprotected groups
+    # existed rather than when some did. Changed to .Count -gt 0 for correct numeric comparison.
     [array]$PrivilegedGroupsWithoutProtection = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "group" -and ($_.RestrictedManagementByRAG -eq $false -and $_.RestrictedManagementByRMAU -eq $False) }
     [array]$PrivilegedGroupWithRMAU = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "group" -and $_.RestrictedManagementByRMAU -eq $True }
     [array]$ScopeNamePrivilegedGroups = $PrivilegedGroupWithRMAU.AssignedAdministrativeUnits | Select-Object -Unique id | ForEach-Object { "/administrativeUnits/$($_.id)" }
@@ -197,6 +202,8 @@ function Update-EntraOpsClassificationControlPlaneScope {
     #region Privileged Service Principals
     Write-Output "Identify directory role scope of service principals and application objects..."
     [array]$PrivilegedServicePrincipals = $PrivilegedObjects | Where-Object { $_.ObjectType -eq "servicePrincipal" }
+    # Initialize before conditional to prevent null reference when no SPs are found
+    # but the .replace('<ScopeNamePrivilegedServicePrincipals>', ...) runs unconditionally below.
     [array]$ScopeNamePrivilegedServicePrincipals = @()
     if ($PrivilegedServicePrincipals.Count -gt 0) {
         # Get list of object-level role assignment scope which includes Control Plane Service Principals

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
@@ -103,6 +103,10 @@ function Update-EntraOpsPrivilegedConditionalAccessGroup {
                             '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)"
                         } | ConvertTo-Json
 
+                        # Use try/catch to prevent M365 group add failures (e.g. member already exists,
+                        # group type doesn't support operation) from aborting the entire CA group sync.
+                        # Use Invoke-EntraOpsMsGraphQuery instead of Invoke-MgGraphRequest for consistent
+                        # error handling, pagination support, and session caching.
                         try {
                             Invoke-EntraOpsMsGraphQuery -Method POST -Uri "/beta/groups/$($GroupId)/members/`$ref" -Body $OdataBody -OutputType PSObject
                         } catch {

--- a/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
+++ b/EntraOps/Public/PrivilegedAccess/Update-EntraOpsPrivilegedConditionalAccessGroup.ps1
@@ -96,14 +96,18 @@ function Update-EntraOpsPrivilegedConditionalAccessGroup {
                         Write-Warning "$($_.InputObject) will be removed from $($GroupName)!"
                         Invoke-EntraOpsMsGraphQuery -Method DELETE -Uri "/beta/groups/$($GroupId)/members/$($_.InputObject)/`$ref" -OutputType PSObject
                     } elseif ($_.SideIndicator -eq "<=") {
-                        $GroupMember = Invoke-MgGraphRequest -Method GET -Uri "/beta/directoryObjects/$($_.InputObject)" -OutputType PSObject
+                        $GroupMember = Invoke-EntraOpsMsGraphQuery -Method GET -Uri "/beta/directoryObjects/$($_.InputObject)" -OutputType PSObject
                         Write-Host "Adding $($GroupMember.displayName) to $($GroupName)"
 
                         $OdataBody = @{
                             '@odata.id' = "https://graph.microsoft.com/beta/directoryObjects/$($_.InputObject)"
                         } | ConvertTo-Json
 
-                        Invoke-MgGraphRequest -Method POST -Uri "/beta/groups/$($GroupId)/members/`$ref" -Body $OdataBody -OutputType PSObject
+                        try {
+                            Invoke-EntraOpsMsGraphQuery -Method POST -Uri "/beta/groups/$($GroupId)/members/`$ref" -Body $OdataBody -OutputType PSObject
+                        } catch {
+                            Write-Warning "Failed to add $($GroupMember.displayName) to $($GroupName). Error: $_"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Multiple bug fixes discovered while running EntraOps v0.5.0 in production against a real Entra ID tenant.

### Bug Fixes

- **Control Plane scope classification (`Update-EntraOpsClassificationControlPlaneScope`):**
  - Add `[array]` type casts to prevent single-object pipeline results from losing `.Count` behavior
  - Fix ObjectType filter: `"user"` → `"group"` for `PrivilegedGroupsWithoutProtection`
  - Fix inverted comparison: `-eq "0"` → `.Count -gt 0` for unprotected devices check
  - Fix string-to-numeric comparisons (`-gt "0"` → `.Count -gt 0`)
  - Initialize `$ScopeNamePrivilegedServicePrincipals` as empty array before conditional block
  - Filter out null/empty AppIds before calling `applications(appId='')` which returns BadRequest

- **CA group sync (`Update-EntraOpsPrivilegedConditionalAccessGroup`):**
  - Use `Invoke-EntraOpsMsGraphQuery` with try/catch in the `elseif` branch (the `if` branch was fixed in f6ff9d3 but the `elseif` was missed)

- **Group owners Graph API (`Get-EntraOpsPrivilegedEntraObject`):**
  - Fix group object section calling `/beta/serviceprincipals/{id}/owners` instead of `/beta/groups/{id}/owners`, causing NotFound for every group

- **ValidateScript path checks:**
  - `New-EntraOpsConfigFile`: validate parent directory instead of file path (file doesn't exist yet since the cmdlet creates it)
  - `Update-EntraOpsClassificationControlPlaneScope` and `Get-EntraOpsClassificationControlPlaneObjects`: remove `Test-Path` on `EntraOpsEamFolder` that fails on first run before `Save-EntraOpsPrivilegedEAMJson` creates the `PrivilegedEAM/` directory

### Warning Noise Reduction

- Change "Empty group {guid}" to `Write-Verbose` with group name and role context across all RBAC role cmdlets (EntraID, IdGov, Device, Defender) — groups with no transitive members are common and not actionable
- Change "Apply classification for role X without role actions" from `Write-Warning` to `Write-Verbose` — this fires per role assignment not per role definition, causing excessive duplicates

## Test plan

- [x] Validated fixes against production Entra ID tenant
- [x] Confirmed Graph API calls use correct endpoints
- [x] Verified first-run scenario works without pre-existing PrivilegedEAM directory
- [x] Confirmed warning output is clean and actionable items are not suppressed